### PR TITLE
Update cmd_get to return an error when no response

### DIFF
--- a/src/param/param_slash.c
+++ b/src/param/param_slash.c
@@ -170,7 +170,7 @@ static int cmd_get(struct slash *slash) {
 
 		if (param_pull_single(param, offset, 1, dest, slash_dfl_timeout, paramver) < 0) {
 			printf("No response\n");
-			continue;
+			return SLASH_EIO;
 		}
 		
 	}


### PR DESCRIPTION
The get command currently doesn't return any error (but a success instead) if their is no response from the remote server when pulling the parameter, whereas all the other functions of the same type (for example set) return the SLASH_EIO error in that case.