### PR TITLE
feature/SI-3470 - Add CRC32 calculation to both the vmem_client and vmem_server

### DIFF
--- a/include/vmem/vmem_client.h
+++ b/include/vmem/vmem_client.h
@@ -14,5 +14,6 @@ void vmem_download(int node, int timeout, uint64_t address, uint32_t length, cha
 void vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t length, int version);
 void vmem_client_list(int node, int timeout, int version);
 int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore);
+int vmem_calculate_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version);
 
 #endif /* LIB_PARAM_INCLUDE_VMEM_VMEM_CLIENT_H_ */

--- a/include/vmem/vmem_client.h
+++ b/include/vmem/vmem_client.h
@@ -14,6 +14,6 @@ void vmem_download(int node, int timeout, uint64_t address, uint32_t length, cha
 void vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t length, int version);
 void vmem_client_list(int node, int timeout, int version);
 int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore);
-int vmem_calculate_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version);
+int vmem_client_calc_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version);
 
 #endif /* LIB_PARAM_INCLUDE_VMEM_VMEM_CLIENT_H_ */

--- a/include/vmem/vmem_crc32.h
+++ b/include/vmem/vmem_crc32.h
@@ -1,0 +1,16 @@
+/*
+ * vmem_crc32.h
+ *
+ *  Created on: Oct 26, 2023
+ *      Author: thomasl
+ */
+
+#ifndef LIB_PARAM_INCLUDE_VMEM_VMEM_CRC32_H_
+#define LIB_PARAM_INCLUDE_VMEM_VMEM_CRC32_H_
+
+#include <stdint.h>
+#include "vmem/vmem.h"
+
+uint32_t vmem_calc_crc32(uint64_t addr, uint32_t len, uint8_t *buffer, uint32_t buffer_len);
+
+#endif /* LIB_PARAM_INCLUDE_VMEM_VMEM_CRC32_H_ */

--- a/include/vmem/vmem_server.h
+++ b/include/vmem/vmem_server.h
@@ -23,6 +23,7 @@ typedef enum {
 	VMEM_SERVER_RESTORE,
 	VMEM_SERVER_BACKUP,
 	VMEM_SERVER_UNLOCK,
+	VMEM_SERVER_CALCULATE_CRC32,
 } vmem_request_type;
 
 typedef struct {

--- a/meson.build
+++ b/meson.build
@@ -47,6 +47,7 @@ param_src = files([
 
 	'src/vmem/vmem_client.c',
 	'src/vmem/vmem_ram.c',
+	'src/vmem/vmem_crc32.c',
 	'src/vmem/vmem_server.c',
 	'src/vmem/vmem.c',
 

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -222,7 +222,7 @@ int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore
 
 }
 
-int vmem_calculate_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version) {
+int vmem_client_calc_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version) {
 
 	int res = -1;
 

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -221,3 +221,54 @@ int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore
 	return (int) response;
 
 }
+
+int vmem_calculate_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version) {
+
+	int res = -1;
+
+	uint32_t time_begin = csp_get_ms();
+
+	/* Establish connection */
+	csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, CSP_O_CRC32);
+	if (conn == NULL)
+		return res;
+
+	csp_packet_t * packet = csp_buffer_get(sizeof(vmem_request_t));
+	if (packet == NULL)
+		return res;
+
+	vmem_request_t * request = (void *) packet->data;
+	request->version = version;
+	request->type = VMEM_SERVER_CALCULATE_CRC32;
+	if (version == 2) {
+		request->data2.address = htobe64(address);
+		request->data2.length = htobe32(length);
+	} else {
+		request->data.address = htobe32((uint32_t)address);
+		request->data.length = htobe32(length);
+	}
+	packet->length = sizeof(vmem_request_t);
+
+	/* Send request */
+	csp_send(conn, packet);
+
+	/* Wait for the reponse from the server */
+	/* Blocking read */
+	packet = csp_read(conn, timeout);
+	if (packet && packet->length >= sizeof(uint32_t)) {
+		uint32_t crc;
+		memcpy(&crc, &packet->data[0], sizeof(crc));
+		(*crc_out) = be32toh(crc);
+		csp_buffer_free(packet);
+		res = 0;
+		uint32_t time_total = csp_get_ms() - time_begin;
+		printf("  Calculated CRC32 0x%08"PRIX32" on %u bytes in %.03f s\n", (*crc_out), (unsigned int) length, time_total / 1000.0);
+	} else {
+		/* Timeout !? */
+		res = -2;
+	}
+
+	csp_close(conn);
+
+	return res;
+}

--- a/src/vmem/vmem_client_slash_ftp.c
+++ b/src/vmem/vmem_client_slash_ftp.c
@@ -210,6 +210,75 @@ static int vmem_client_slash_upload(struct slash *slash)
 }
 slash_command(upload, vmem_client_slash_upload, "<file> <address>", "Upload from FILE to VMEM");
 
+static int vmem_client_slash_crc32(struct slash *slash) {
+
+	unsigned int node = slash_dfl_node;
+    unsigned int timeout = slash_dfl_timeout;
+    unsigned int version = 1;
+
+    optparse_t * parser = optparse_new("crc32", "<address> <length base10 or base16>");
+    optparse_add_help(parser);
+    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+    optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
+    optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
+
+    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+    if (argi < 0) {
+        optparse_del(parser);
+	    return SLASH_EINVAL;
+    }
+
+	/* Expect address */
+	if (++argi >= slash->argc) {
+		printf("missing address\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+
+	char * endptr;
+	uint64_t address = strtoul(slash->argv[argi], &endptr, 16);
+	if (*endptr != '\0') {
+		printf("Failed to parse address\n");
+        optparse_del(parser);
+		return SLASH_EUSAGE;
+	}
+
+	/* Expect length */
+	if (++argi >= slash->argc) {
+		printf("missing length\n");
+        optparse_del(parser);
+		return SLASH_EINVAL;
+	}
+
+	uint32_t length = strtoul(slash->argv[argi], &endptr, 10);
+	if (*endptr != '\0') {
+		length = strtoul(slash->argv[argi], &endptr, 16);
+		if (*endptr != '\0') {
+			printf("Failed to parse length in base 10 or base 16\n");
+            optparse_del(parser);
+			return SLASH_EUSAGE;
+		}
+	}
+
+    optparse_del(parser);
+
+	printf("Calculate CRC32 from %u addr 0x%"PRIX64" with timeout %u, version %u\n", node, address, timeout, version);
+
+	uint32_t crc;
+	int res = vmem_calculate_crc32(node, timeout, address, length, &crc, version);
+
+	if (res) {
+		if (res == -1) {
+			return SLASH_ENOMEM;
+		} else if (res == -2) {
+			return SLASH_EIO;
+		}
+	}
+
+	return SLASH_SUCCESS;
+}
+slash_command(crc32, vmem_client_slash_crc32, "<address> <length>", "Calculate CRC32 on a VMEM area");
+
 unsigned int rdp_dfl_window = 3;
 unsigned int rdp_dfl_conn_timeout = 10000;
 unsigned int rdp_dfl_packet_timeout = 5000;

--- a/src/vmem/vmem_client_slash_ftp.c
+++ b/src/vmem/vmem_client_slash_ftp.c
@@ -213,25 +213,25 @@ slash_command(upload, vmem_client_slash_upload, "<file> <address>", "Upload from
 static int vmem_client_slash_crc32(struct slash *slash) {
 
 	unsigned int node = slash_dfl_node;
-    unsigned int timeout = slash_dfl_timeout;
-    unsigned int version = 1;
+	unsigned int timeout = slash_dfl_timeout;
+	unsigned int version = 1;
 
-    optparse_t * parser = optparse_new("crc32", "<address> <length base10 or base16>");
-    optparse_add_help(parser);
-    optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
-    optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
-    optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
+	optparse_t * parser = optparse_new("crc32", "<address> <length base10 or base16>");
+	optparse_add_help(parser);
+	optparse_add_unsigned(parser, 'n', "node", "NUM", 0, &node, "node (default = <env>)");
+	optparse_add_unsigned(parser, 't', "timeout", "NUM", 0, &timeout, "timeout (default = <env>)");
+	optparse_add_unsigned(parser, 'v', "version", "NUM", 0, &version, "version (default = 1)");
 
-    int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
-    if (argi < 0) {
-        optparse_del(parser);
-	    return SLASH_EINVAL;
-    }
+	int argi = optparse_parse(parser, slash->argc - 1, (const char **) slash->argv + 1);
+	if (argi < 0) {
+		optparse_del(parser);
+		return SLASH_EINVAL;
+	}
 
 	/* Expect address */
 	if (++argi >= slash->argc) {
 		printf("missing address\n");
-        optparse_del(parser);
+		optparse_del(parser);
 		return SLASH_EINVAL;
 	}
 
@@ -239,14 +239,14 @@ static int vmem_client_slash_crc32(struct slash *slash) {
 	uint64_t address = strtoul(slash->argv[argi], &endptr, 16);
 	if (*endptr != '\0') {
 		printf("Failed to parse address\n");
-        optparse_del(parser);
+		optparse_del(parser);
 		return SLASH_EUSAGE;
 	}
 
 	/* Expect length */
 	if (++argi >= slash->argc) {
 		printf("missing length\n");
-        optparse_del(parser);
+		optparse_del(parser);
 		return SLASH_EINVAL;
 	}
 
@@ -255,12 +255,12 @@ static int vmem_client_slash_crc32(struct slash *slash) {
 		length = strtoul(slash->argv[argi], &endptr, 16);
 		if (*endptr != '\0') {
 			printf("Failed to parse length in base 10 or base 16\n");
-            optparse_del(parser);
+			optparse_del(parser);
 			return SLASH_EUSAGE;
 		}
 	}
 
-    optparse_del(parser);
+	optparse_del(parser);
 
 	printf("Calculate CRC32 from %u addr 0x%"PRIX64" with timeout %u, version %u\n", node, address, timeout, version);
 

--- a/src/vmem/vmem_client_slash_ftp.c
+++ b/src/vmem/vmem_client_slash_ftp.c
@@ -265,7 +265,7 @@ static int vmem_client_slash_crc32(struct slash *slash) {
 	printf("Calculate CRC32 from %u addr 0x%"PRIX64" with timeout %u, version %u\n", node, address, timeout, version);
 
 	uint32_t crc;
-	int res = vmem_calculate_crc32(node, timeout, address, length, &crc, version);
+	int res = vmem_client_calc_crc32(node, timeout, address, length, &crc, version);
 
 	if (res) {
 		if (res == -1) {

--- a/src/vmem/vmem_crc32.c
+++ b/src/vmem/vmem_crc32.c
@@ -1,0 +1,42 @@
+/*
+ * vmem_crc32.c
+ *
+ *  Created on: Oct 26, 2023
+ *      Author: thomasl
+ */
+
+#include <stdint.h>
+#include <string.h>
+
+#include "vmem/vmem_crc32.h"
+#include "csp/csp_crc32.h"
+
+uint32_t vmem_calc_crc32(uint64_t addr, uint32_t len, uint8_t * buffer, uint32_t buffer_len) {
+
+	csp_crc32_t crc_obj;
+	uint32_t count = 0;
+	uint32_t chunk_len;
+
+	csp_crc32_init(&crc_obj);
+
+	/* We already have a packet from the request, so use that */
+	while (count < len) {
+		/* Get the minimum size of each chunk */
+		chunk_len = (buffer_len > (len - count) ? (len - count) : buffer_len);
+
+		/* Grab the data from the vmem area */
+		vmem_memcpy(buffer, (void *) ((intptr_t) addr + count), chunk_len);
+
+		/* Update CRC32 calculation */
+		csp_crc32_update(&crc_obj, buffer, chunk_len);
+
+		/* Increment */
+		count += chunk_len;
+	}
+
+	/* Finalize the CRC32 calculation */
+	uint32_t crc = csp_crc32_final(&crc_obj);
+
+	return crc;
+
+}

--- a/src/vmem/vmem_crc32.c
+++ b/src/vmem/vmem_crc32.c
@@ -8,6 +8,7 @@
 #include <stdint.h>
 #include <string.h>
 
+#include "vmem/vmem.h"
 #include "vmem/vmem_crc32.h"
 #include "csp/csp_crc32.h"
 


### PR DESCRIPTION
Added crc32 slash command to the vmem_client, which utilizes a new vmem server operation which can calculate crc32 checksums on any vmem area and return the result to the requesting host