### PR TITLE
Re-implement CSP servers to use connection status check

### DIFF
--- a/src/vmem/vmem_server.c
+++ b/src/vmem/vmem_server.c
@@ -62,7 +62,7 @@ void vmem_server_handler(csp_conn_t * conn)
 			 */
 			csp_buffer_free(packet);
 
-			while(count < length) {
+			while((count < length) && csp_conn_is_active(conn)) {
 				/* Prepare packet */
 				csp_packet_t * packet = csp_buffer_get(VMEM_SERVER_MTU);
 				if (packet == NULL) {


### PR DESCRIPTION
Implemented SI-3934 in the VMEM server. The VMEM server now detects connection timeouts on a RDP connection. This means that the sever will stop sending packets if the client has gone away.