### PR TITLE
Add vmem_mmap implementation

### DIFF
--- a/include/vmem/vmem_mmap.h
+++ b/include/vmem/vmem_mmap.h
@@ -11,7 +11,6 @@ typedef struct {
 	char * filename;
 } vmem_mmap_driver_t;
 
-void vmem_mmap_init(vmem_t * vmem);
 void vmem_mmap_read(vmem_t * vmem, uint32_t addr, void * dataout, uint32_t len);
 void vmem_mmap_write(vmem_t * vmem, uint32_t addr, const void * datain, uint32_t len);
 
@@ -34,6 +33,7 @@ void vmem_mmap_write(vmem_t * vmem, uint32_t addr, const void * datain, uint32_t
 		.ack_with_pull = 1, \
 	};
 
+/// Helper macro to help reference the vmem_t variable created behind the scene by the VMEM_DEFINE_MMAP macro above
 #define VMEM_MMAP_VAR(name_in) vmem_mmap_##name_in
 
 #ifdef __cplusplus

--- a/include/vmem/vmem_mmap.h
+++ b/include/vmem/vmem_mmap.h
@@ -1,0 +1,41 @@
+#pragma once
+
+#include <vmem/vmem.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct {
+	void * physaddr;
+	char * filename;
+} vmem_mmap_driver_t;
+
+void vmem_mmap_init(vmem_t * vmem);
+void vmem_mmap_read(vmem_t * vmem, uint32_t addr, void * dataout, uint32_t len);
+void vmem_mmap_write(vmem_t * vmem, uint32_t addr, const void * datain, uint32_t len);
+
+#define VMEM_DEFINE_MMAP(name_in, strname, filename_in, size_in) \
+	static vmem_mmap_driver_t vmem_mmap_##name_in##_driver = { \
+		.physaddr = 0, \
+		.filename = filename_in, \
+	}; \
+	__attribute__((section("vmem"))) \
+	__attribute__((aligned(1))) \
+	__attribute__((used)) \
+	vmem_t vmem_mmap_##name_in = { \
+		.type = VMEM_TYPE_FILE, \
+		.name = strname, \
+		.size = size_in, \
+		.read = vmem_mmap_read, \
+		.write = vmem_mmap_write, \
+		.driver = &vmem_mmap_##name_in##_driver, \
+		.vaddr = 0, \
+		.ack_with_pull = 1, \
+	};
+
+#define VMEM_MMAP_VAR(name_in) vmem_mmap_##name_in
+
+#ifdef __cplusplus
+}
+#endif

--- a/meson.build
+++ b/meson.build
@@ -15,7 +15,14 @@ if get_option('have_float') == false
 endif
 
 if get_option('have_fopen') == true
-	conf.set('MPACK_STDIO', 1)
+	if get_option('list_dynamic') == true
+		conf.set('MPACK_STDIO', 1)
+	else
+		warning('*********')
+		warning('Enabling \'have_fopen\' without also enabling \'list_dynamic\' causes mpack related build failures, setting MPACK_STDIO=0')
+		warning('*********')
+		conf.set('MPACK_STDIO', 0)
+	endif
 endif
 
 libparam_h = configure_file(output: 'libparam.h', configuration: conf)
@@ -57,6 +64,7 @@ param_src = files([
 if get_option('have_fopen') == true
 	param_src += files([
 		'src/vmem/vmem_file.c',
+		'src/vmem/vmem_mmap.c',
 		#'src/param/list/param_list_store_vmem.c',
 	])
 endif

--- a/src/vmem/vmem_mmap.c
+++ b/src/vmem/vmem_mmap.c
@@ -6,7 +6,7 @@
 #include <unistd.h>
 #include <fcntl.h>
 
-static void ensure_init(vmem_mmap_driver_t *drv, uint32_t size)
+static void ensure_init(vmem_mmap_driver_t *drv, uint32_t *size)
 {
 	if (0 == drv->physaddr)
 	{
@@ -16,8 +16,15 @@ static void ensure_init(vmem_mmap_driver_t *drv, uint32_t size)
 			perror("open");
 			return;
 		}
-		ftruncate(fd, size);
-		drv->physaddr = mmap(0, size, PROT_WRITE|PROT_READ, MAP_SHARED, fd, 0);
+		long cur_size = lseek(fd, 0, SEEK_END);
+		if (cur_size < *size) {
+			/* Grow the file if needed */
+			ftruncate(fd, *size);
+		} else {
+			/* File size is >= requested size, don't destroy/truncate data but adjust the driver size instead */
+			*size = cur_size;
+		}
+		drv->physaddr = mmap(0, *size, PROT_WRITE|PROT_READ, MAP_SHARED, fd, 0);
 		close(fd);
 		if (drv->physaddr == MAP_FAILED)
 		{
@@ -30,22 +37,22 @@ static void ensure_init(vmem_mmap_driver_t *drv, uint32_t size)
 void vmem_mmap_read(vmem_t *vmem, uint32_t addr, void *dataout, uint32_t len)
 {
 	vmem_mmap_driver_t *drv = (vmem_mmap_driver_t *)vmem->driver;
-	ensure_init(drv, vmem->size);
+	ensure_init(drv, &vmem->size);
 	memcpy(dataout, ((vmem_mmap_driver_t *)vmem->driver)->physaddr + addr, len);
 }
 
 void vmem_mmap_write(vmem_t *vmem, uint32_t addr, const void *datain, uint32_t len)
 {
 	vmem_mmap_driver_t *drv = (vmem_mmap_driver_t *)vmem->driver;
-	ensure_init(drv, vmem->size);
+	ensure_init(drv, &vmem->size);
 	if ((addr + len) >  vmem->size) {
 		// Grow the file...
 		if (msync(drv->physaddr, vmem->size, MS_SYNC|MS_INVALIDATE) == -1) {
 			perror("Could not sync the file to disk");
 		}
-		vmem->size += 4096 * 1000;
+		vmem->size = (addr + len);
 		drv->physaddr = 0;
-		ensure_init(drv, vmem->size);
+		ensure_init(drv, &vmem->size);
 	}
 	memcpy(drv->physaddr + addr, datain, len);
 }

--- a/src/vmem/vmem_mmap.c
+++ b/src/vmem/vmem_mmap.c
@@ -1,0 +1,44 @@
+#include <string.h>
+#include <stdio.h>
+#include <vmem/vmem_mmap.h>
+#include <sys/mman.h>
+#include <sys/types.h>
+#include <unistd.h>
+#include <fcntl.h>
+
+static void ensure_init(vmem_mmap_driver_t *drv, uint32_t size)
+{
+	if (0 == drv->physaddr)
+	{
+		int fd;
+		if ((fd = open(drv->filename, O_CREAT|O_RDWR, 0600)) == -1)
+		{
+			perror("open");
+			return;
+		}
+		ftruncate(fd, size);
+		drv->physaddr = mmap(0, size, PROT_WRITE|PROT_READ, MAP_SHARED, fd, 0);
+		if (drv->physaddr == MAP_FAILED)
+		{
+			perror("mmap");
+			return;
+		}
+	}
+}
+
+void vmem_mmap_read(vmem_t *vmem, uint32_t addr, void *dataout, uint32_t len)
+{
+	vmem_mmap_driver_t *drv = (vmem_mmap_driver_t *)vmem->driver;
+	ensure_init(drv, vmem->size);
+	memcpy(dataout, ((vmem_mmap_driver_t *)vmem->driver)->physaddr + addr, len);
+}
+
+void vmem_mmap_write(vmem_t *vmem, uint32_t addr, const void *datain, uint32_t len)
+{
+	vmem_mmap_driver_t *drv = (vmem_mmap_driver_t *)vmem->driver;
+	ensure_init(drv, vmem->size);
+	memcpy(drv->physaddr + addr, datain, len);
+ 	if (msync(drv->physaddr, vmem->size, MS_SYNC|MS_INVALIDATE) == -1) {
+        perror("Could not sync the file to disk");
+    }
+}


### PR DESCRIPTION
- drive-by fix: prevent build failures when enabling "have_fopen" without also enabling "list_dynamic"