### PR TITLE
Refactored vmem_client_find to support vmem_list2_t

### DIFF
--- a/include/vmem/vmem_client.h
+++ b/include/vmem/vmem_client.h
@@ -14,7 +14,7 @@
 int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp);
 int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t length, int version);
 void vmem_client_list(int node, int timeout, int version);
-vmem_list_t vmem_client_find(int node, int timeout, int version, char * name, int namelen);
+int vmem_client_find(int node, int timeout, void * dataout, int version, char * name, int namelen);
 int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore);
 int vmem_client_calc_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version);
 


### PR DESCRIPTION
This pull request modifies the `vmem_client_find` function to return either `vmem_list_t` or `vmem_list2_t`. This update is crucial for supporting 64-bit virtual addresses (`vaddr`), as further explained in issue #17. 

Key Changes:
- Implemented dataout buffer for `vmem_client_find` to support dynamic type response based on version number.
- Changed return type of `vmem_client_find` to indicate success or failure.
- Updated header file and function signature accordingly.

This contribution is from the DISCO-2 Payload Software Group, following our discussion on April 4, 2024. Our aim is to address and close issue #17 with this update.