### PR TITLE
SI-4712 Change param_t.timestamp from uint32_t to csp_timestamp_t

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -10,6 +10,7 @@
 
 #include <stdint.h>
 #include <vmem/vmem.h>
+#include <csp/csp_types.h>
 
 #include "libparam.h"
 
@@ -103,7 +104,7 @@ typedef struct param_s {
 
 	/* Local info */
 	void (*callback)(struct param_s * param, int offset);
-	uint32_t * timestamp;
+	csp_timestamp_t * timestamp;
 
 #ifdef PARAM_HAVE_SYS_QUEUE
 	/* single linked list:
@@ -129,7 +130,7 @@ typedef struct param_s {
  */
 #define PARAM_DEFINE_STATIC_RAM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
-	uint32_t _timestamp_##_name = 0; \
+	csp_timestamp_t _timestamp_##_name = {0}; \
 	__attribute__((section("param"))) \
 	__attribute__((aligned(1))) \
 	__attribute__((used)) \
@@ -151,7 +152,7 @@ typedef struct param_s {
 
 #define PARAM_DEFINE_STATIC_VMEM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _vmem_name, _vmem_addr, _docstr) \
 	; /* Catch const param defines */ \
-	uint32_t _timestamp_##_name = 0; \
+	csp_timestamp_t _timestamp_##_name = {0}; \
 	__attribute__((section("param"))) \
 	__attribute__((aligned(1))) \
 	__attribute__((used)) \
@@ -175,7 +176,7 @@ typedef struct param_s {
 
 #define PARAM_DEFINE_REMOTE(_name, _node, _id, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
-	uint32_t _timestamp_##_name = 0; \
+	csp_timestamp_t _timestamp_##_name = {0}; \
 	__attribute__((section("param"))) \
 	__attribute__((aligned(1))) \
 	__attribute__((used)) \
@@ -194,7 +195,7 @@ typedef struct param_s {
 
 #define PARAM_DEFINE_REMOTE_DYNAMIC(_id, _name, _node, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
-	uint32_t _timestamp_##_name = 0; \
+	csp_timestamp_t _timestamp_##_name = {0}; \
 	param_t _name = { \
 		.node = _node, \
 		.id = _id, \

--- a/include/param/param_queue.h
+++ b/include/param/param_queue.h
@@ -52,15 +52,16 @@ typedef int (*param_queue_callback_f)(void * context, param_queue_t *queue, para
 int param_queue_foreach(param_queue_t *queue, param_queue_callback_f callback, void * context);
 
 
-void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, long unsigned int *timestamp, int *offset, param_queue_t *queue);
+void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, csp_timestamp_t *timestamp, int *offset, param_queue_t *queue);
 
 #define PARAM_QUEUE_FOREACH(param, reader, queue, offset) \
 	mpack_reader_t reader; \
 	mpack_reader_init_data(&reader, queue->buffer, queue->used); \
 	while(reader.data < reader.end) { \
 		int id, node, offset = -1; \
-		long unsigned int timestamp = 0; \
-		param_deserialize_id(&reader, &id, &node, &timestamp, &offset, queue); \
+		csp_timestamp_t _timestamp = {0}; \
+		param_deserialize_id(&reader, &id, &node, &_timestamp, &offset, queue); \
+		uint32_t timestamp __attribute__((unused)) = _timestamp.tv_sec; /* For backwards compatiblity with timestamp before csp_timestamp_t */ \
 		param_t * param = param_list_find_id(node, id); \
 
 

--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -550,7 +550,7 @@ typedef struct param_heap_s {
 		uint64_t alignme;
 		uint8_t *buffer;
 	};
-	uint32_t timestamp;
+	csp_timestamp_t timestamp;
 	char name[36];
 	char unit[10];
 	char help[150];

--- a/src/param/param_client.c
+++ b/src/param/param_client.c
@@ -44,7 +44,7 @@ static void param_transaction_callback_pull(csp_packet_t *response, int verbose,
 		mpack_reader_init_data(&reader, queue.buffer, queue.used);
 		while(reader.data < reader.end) {
 			int id, node, offset = -1;
-			long unsigned int timestamp = 0;
+			csp_timestamp_t timestamp = {0};
 			param_deserialize_id(&reader, &id, &node, &timestamp, &offset, &queue);
 			if (node == 0)
 				node = from;
@@ -272,7 +272,7 @@ int param_push_single(param_t *param, int offset, void *value, int verbose, int 
 	}
 
 	/* If it was a remote parameter, set the value after the ack but not if ack with push which sets param timestamp */
-	if (param->node != 0 && value != NULL && *param->timestamp == 0)
+	if (param->node != 0 && value != NULL && param->timestamp->tv_sec == 0)
 	{
 		if (offset < 0) {
 			for (int i = 0; i < param->array_size; i++)

--- a/src/param/param_queue.c
+++ b/src/param/param_queue.c
@@ -62,7 +62,7 @@ int param_queue_apply(param_queue_t *queue, int apply_local, int from) {
 	mpack_reader_init_data(&reader, queue->buffer, queue->used);
 	while(reader.data < reader.end) {
 		int id, node, offset = -1;
-		long unsigned int timestamp = 0;
+		csp_timestamp_t timestamp = {0};
 		param_deserialize_id(&reader, &id, &node, &timestamp, &offset, queue);
 
 		/* If the from address is set, and the nodeid is 0, substitue with the source address */
@@ -198,7 +198,7 @@ void param_queue_print_params(param_queue_t *queue, uint32_t ref_timestamp) {
 			mpack_reader_init_data(&_reader, queue->buffer, queue->used);
 			while(outer_count > inner_counter) {
 				int _id, _node, _offset = -1;
-				long unsigned int _timestamp = 0;
+				csp_timestamp_t _timestamp = {0};
 				param_deserialize_id(&_reader, &_id, &_node, &_timestamp, &_offset, queue);
 				param_t * _param = param_list_find_id(_node, _id);
 				if(queue->type == PARAM_QUEUE_TYPE_SET){

--- a/src/param/param_serializer.c
+++ b/src/param/param_serializer.c
@@ -52,7 +52,7 @@ void param_serialize_id(mpack_writer_t *writer, param_t *param, int offset, para
 	} else {
 
 		int node = param->node;
-		uint32_t timestamp = *param->timestamp;
+		uint32_t timestamp = param->timestamp->tv_sec;
 		int array_flag = (offset >= 0) ? 1 : 0;
 		int node_flag = (queue->last_node != node) ? 1 : 0;
 		int timestamp_flag = (queue->last_timestamp != timestamp) ? 1 : 0;
@@ -88,7 +88,7 @@ void param_serialize_id(mpack_writer_t *writer, param_t *param, int offset, para
 
 }
 
-void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, long unsigned int *timestamp, int *offset, param_queue_t *queue) {
+void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, csp_timestamp_t *timestamp, int *offset, param_queue_t *queue) {
 
 	if (queue->version == 1) {
 
@@ -140,10 +140,10 @@ void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, long unsig
 			uint32_t _timestamp;
 			mpack_read_bytes(reader, (char*) &_timestamp, 4);
 			_timestamp = be32toh(_timestamp);
-			*timestamp = _timestamp;
+			timestamp->tv_sec = _timestamp;
 			queue->last_timestamp = _timestamp;
 		} else {
-			*timestamp = queue->last_timestamp;
+			timestamp->tv_sec = queue->last_timestamp;
 		}
 
 		if (extendedid_flag) {

--- a/src/param/param_serializer.h
+++ b/src/param/param_serializer.h
@@ -14,7 +14,7 @@
 #include <mpack/mpack.h>
 
 void param_serialize_id(mpack_writer_t *writer, param_t * param, int offset, param_queue_t * queue);
-void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, long unsigned int *timestamp, int *offset, param_queue_t * queue);
+void param_deserialize_id(mpack_reader_t *reader, int *id, int *node, csp_timestamp_t *timestamp, int *offset, param_queue_t * queue);
 
 int param_serialize_to_mpack(param_t * param, int offset, mpack_writer_t * writer, void * value, param_queue_t * queue);
 void param_deserialize_from_mpack_to_param(void * context, void * queue, param_t * param, int offset, mpack_reader_t * reader);

--- a/src/param/param_server.c
+++ b/src/param/param_server.c
@@ -86,7 +86,7 @@ static void param_serve_pull_request(csp_packet_t * request, int all, int versio
 
 		while(reader.data < reader.end) {
 			int id, node, offset = -1;
-			long unsigned int timestamp = 0;
+			csp_timestamp_t timestamp = {0};
 			param_deserialize_id(&reader, &id, &node, &timestamp, &offset, &q_request);
 			if (server_addr == node)
 				node = 0;
@@ -102,7 +102,7 @@ static void param_serve_pull_request(csp_packet_t * request, int all, int versio
 					int found = 0;
 					while(_reader.data < _reader.end) {
 						int _id, _node, _offset = -1;
-						long unsigned int _timestamp = 0;
+						csp_timestamp_t _timestamp = {0};
 						param_deserialize_id(&_reader, &_id, &_node, &_timestamp, &_offset, &ctx.q_response);
 						if (server_addr == _node)
 							_node = 0;

--- a/src/param/param_slash.c
+++ b/src/param/param_slash.c
@@ -282,7 +282,7 @@ static int cmd_set(struct slash *slash) {
 			dest = server;
 		csp_timestamp_t time_now;
 		csp_clock_get_time(&time_now);
-		*param->timestamp = 0;
+		memset(&param->timestamp, 0, sizeof(csp_timestamp_t));
 		if (param_push_single(param, offset, valuebuf, 0, dest, slash_dfl_timeout, paramver, ack_with_pull) < 0) {
 			printf("No response\n");
 			optparse_del(parser);
@@ -367,7 +367,7 @@ static int cmd_add(struct slash *slash) {
 			return SLASH_EINVAL;
 		}
 		/* clear param timestamp so we dont set timestamp flag when serialized*/
-		*param->timestamp = 0;
+		memset(&param->timestamp, 0, sizeof(csp_timestamp_t));
 
 		if (param_queue_add(&param_queue, param, offset, valuebuf) < 0)
 			printf("Queue full\n");

--- a/src/param/param_string.c
+++ b/src/param/param_string.c
@@ -272,7 +272,7 @@ void param_print_file(FILE* file, param_t * param, int offset, int nodes[], int 
 	if (param == NULL)
 		return;
 
-	if(ref_timestamp && ref_timestamp > *param->timestamp){
+	if(ref_timestamp && ref_timestamp > param->timestamp->tv_sec){
 		fprintf(file, "\033[90m");
 	} else {
 		fprintf(file, "%s", param_mask_color(param));


### PR DESCRIPTION
1. Change param_t.timestamp from uint32_t to csp_timestamp_t to support higher stored resolution.
2. Incorporate receiver timestamp annotation into libparam (where it is currently done in param_sniffer.c)
3. Consider support for sending higher parameter timestamp resolution over CSP.
