### PR TITLE
Si 569 enhanced set array

### DIFF
--- a/src/param/param_slash.c
+++ b/src/param/param_slash.c
@@ -77,12 +77,8 @@ static int param_slash_parse_array(char * arg, int node, param_t **param, int *s
 	//  :   ->    first_scan == 0 | second_scan == 1
 	//  :7  ->    first_scan == 0 | second_scan == 2
 
-	if(first_scan > second_scan){
-		if(first_scan > 1) *slice_detected = 1;
-	} 
-	else {
-		*slice_detected = 1;
-	}
+	if(first_scan > 1 || second_scan > first_scan) *slice_detected = 1;
+
 	return 0;
 
 }

--- a/src/param/param_slash.c
+++ b/src/param/param_slash.c
@@ -90,10 +90,6 @@ static int param_slash_parse_array(char * arg, int node, param_t **param, int *s
  	// 4. [:]    ->    first_scan == 0 | second_scan == 1
 	// 5. [:7]   ->    first_scan == 0 | second_scan == 2
 	// 1st and 2nd outcome we need to check on _slice_delimitor, if it is : then set slice_detected to 1
-		
-	printf("first  : %d\n", first_scan);
-	printf("second : %d\n", second_scan);
-
 	return 0;
 
 }

--- a/src/param/param_string.c
+++ b/src/param/param_string.c
@@ -246,8 +246,12 @@ static void param_print_value(FILE * file, param_t * param, int offset) {
 		sprintf(value_str + strlen(value_str), "[");
 
 	for(int i = offset; i < offset + count; i++) {
-		
-		param_value_str(param, i, value_str + strlen(value_str), 128 - strlen(value_str));
+		if(*param->timestamp > 0){
+			param_value_str(param, i, value_str + strlen(value_str), 128 - strlen(value_str));
+		}
+		else {
+			sprintf(value_str + strlen(value_str), "-");
+		}
 
 		if (i + 1 < count)
 			sprintf(value_str + strlen(value_str), " ");
@@ -391,23 +395,24 @@ void param_print_file(FILE* file, param_t * param, int offset, int nodes[], int 
 
 	}
 
-	if (*param->timestamp > 0){		
-		struct tm timestamp;
-		char timestamp_buffer[40];
-		time_t param_timestamp = (time_t)*param->timestamp;
-		timestamp = *localtime(&param_timestamp);
-		strftime(timestamp_buffer, sizeof(timestamp_buffer), "%a %Y-%m-%d %H:%M:%S %Z", &timestamp);
-
-		fprintf(file, "\t%s", timestamp_buffer);
-	}
-	else{
-		fprintf(file, "\t%s", "-");
-	}
-	
 	if ((verbose >= 3) && (param->docstr != NULL)) {
 		fprintf(file, "\t\t%s", param->docstr);
 	}
+	
+	if(verbose >= 4){
+		if (*param->timestamp > 0){		
+			struct tm timestamp;
+			char timestamp_buffer[40];
+			time_t param_timestamp = (time_t)*param->timestamp;
+			timestamp = *localtime(&param_timestamp);
+			strftime(timestamp_buffer, sizeof(timestamp_buffer), "%a %Y-%m-%d %H:%M:%S %Z", &timestamp);
 
+			fprintf(file, "\t%s", timestamp_buffer);
+		}
+		else{
+			fprintf(file, "\t%s", "-");
+		}
+	}
 
 	fprintf(file, "%s", param_mask_color_off());
 

--- a/src/param/param_string.c
+++ b/src/param/param_string.c
@@ -18,7 +18,7 @@
 #include <param/param.h>
 #include <param/param_list.h>
 #include <time.h>
-
+#include <slash/dflopt.h>
 
 #ifndef MIN
 #define MIN(a,b) (((a)<(b))?(a):(b))
@@ -246,7 +246,7 @@ static void param_print_value(FILE * file, param_t * param, int offset) {
 		sprintf(value_str + strlen(value_str), "[");
 
 	for(int i = offset; i < offset + count; i++) {
-		if(*param->timestamp > 0){
+		if(*param->timestamp > 0 || slash_dfl_node == 0){
 			param_value_str(param, i, value_str + strlen(value_str), 128 - strlen(value_str));
 		}
 		else {


### PR DESCRIPTION
Rewrote parts of 'cmd_set' to handle setting parts of an array to an array of values.
Example usages:
Example param array: arr = {1, 2, 3, 4, 5, 6, 7, 8}
- (specific slice with value array) set arr[2:5] [9 9 9] -> {1, 2, 9, 9, 9, 6, 7, 8}
- (specific slice with single value) set arr[2:5] 9 -> {1, 2, 9, 9, 9, 6, 7, 8}
- (No slice with value array) set arr [5 4 5 4 5 4 5 4] -> {5, 4, 5, 4, 5, 4, 5, 4}
- (Negative index) set arr[-5:7] [1 2 3 4] -> {1, 2, 3, 1, 2, 3, 4, 8}
- (No start index) set arr[:5] [6 6 6 6] -> {6, 6, 6, 6, 2, 3, 4, 8}
- (No end index) set arr[5:] [6 6 6 6] -> {1, 2, 3, 4, 6, 6, 6, 6}
- (No index) set arr[:] [6 6 6 6 6 6 6 6] -> {6, 6, 6, 6, 6, 6, 6, 6}
The value array has to match the length of the slice. If it doesn't, then cmd_set will return SLASH_EINVAL.

Any feedback is very much appreciated.