### PR TITLE
SI-4694 - Add generation of "PARAM_VMEM_64_BITS_API" macro in libparam.h

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-22.04
 
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,26 @@
+name: libparam CI
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  ci:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-python@v1
+      - name: Install gcovr
+        run: pip3 install gcovr==5.0      
+      - uses: BSFishy/meson-build@v1.0.3
+        with:
+          action: build
+          options: --verbose
+          setup-options: -Db_coverage=true
+          directory: builddir
+          meson-version: 1.5.1
+          ninja-version: 1.11.1.1
+          gcovr-version: 5.0
+      - name: Run gcovr
+        run: ninja -C builddir test coverage-text && tail -n3 builddir/meson-logs/coverage.txt

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
         with:
           action: build
           options: --verbose
-          setup-options: -Db_coverage=true
+          setup-options: -Db_coverage=true -Ddefault_library=static
           directory: builddir
           meson-version: 1.5.1
           ninja-version: 1.11.1.1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,1 @@
-![build.yml status](https://github.com/spaceinventor/libparam/actions/workflows/build.yml/badge.svg)
+![build.yml status](https://github.com/spaceinventor/libparam/actions/workflows/ci.yml/badge.svg)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,1 @@
+![build.yml status](https://github.com/spaceinventor/libparam/actions/workflows/build.yml/badge.svg)

--- a/lib/csp.wrap
+++ b/lib/csp.wrap
@@ -1,0 +1,4 @@
+[wrap-git]
+url = https://github.com/spaceinventor/libcsp.git
+revision = HEAD
+depth = 1

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('param', 'c', 'cpp', subproject_dir:'lib')
+project('param', 'c', subproject_dir:'lib')
 
 conf = configuration_data()
 conf.set('PARAM_HAVE_SYS_QUEUE', get_option('list_dynamic') or get_option('list_pool') > 0)

--- a/meson.build
+++ b/meson.build
@@ -1,4 +1,4 @@
-project('param', 'c')
+project('param', 'c', 'cpp', subproject_dir:'lib')
 
 conf = configuration_data()
 conf.set('PARAM_HAVE_SYS_QUEUE', get_option('list_dynamic') or get_option('list_pool') > 0)
@@ -6,6 +6,16 @@ conf.set('PARAM_LIST_DYNAMIC', get_option('list_dynamic'))
 conf.set('PARAM_LIST_POOL', get_option('list_pool'))
 conf.set('PARAM_HAVE_SCHEDULER', get_option('scheduler'))
 conf.set('PARAM_HAVE_COMMANDS', get_option('commands'))
+# From now on, VMEM API is 64bits, breaking earlier ABI. 
+# New user code can use the fact that this macro is defined (its value is not relevant, just the fact that it is defined)
+# to check that the libparam version included (typically through convoluted dependency paths) does support the 64-bits API
+# and #error if it doesnt.
+VMEM_64_BITS_API_description = '''From now on, VMEM API is 64bits, breaking earlier ABI. 
+New user code can use the fact that this macro is defined (its value is not relevant, just the fact that it is defined)
+to check that the libparam version included (typically through convoluted dependency paths) does support the 64-bits API
+and #error if it doesnt.'''
+
+conf.set('PARAM_VMEM_64_BITS_API', 1, description: VMEM_64_BITS_API_description)
 
 if get_option('have_float') == false
 	conf.set('MPACK_FLOAT', 0)
@@ -144,3 +154,7 @@ param_lib = library('param',
 )
 
 param_dep = declare_dependency(include_directories : param_inc, link_with : param_lib)
+
+if not meson.is_subproject()
+	subdir('tests')
+endif

--- a/meson.build
+++ b/meson.build
@@ -156,5 +156,5 @@ param_lib = library('param',
 param_dep = declare_dependency(include_directories : param_inc, link_with : param_lib)
 
 if not meson.is_subproject()
-	subdir('tests')
+    subdir('tests')
 endif

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,13 +1,7 @@
-if not meson.is_subproject()
-    cmake = import('cmake')
-    gtest_proj = cmake.subproject('gtest')
-    gtest_dep = gtest_proj.get_variable('gtest_dep') 
-    gtest_main_dep = gtest_proj.get_variable('gtest_main_dep') 
-    gmock_dep = gtest_proj.get_variable('gmock_dep') 
-    gtest_lib = static_library('gtest', install : false)
-    gmock_lib = static_library('gmock', install: false) 
-endif
-
+add_languages('cpp')
+gtest_dep = dependency('gtest', main : true)
+gtest_main_dep = dependency('gtest_main')
+gmock_dep = dependency('gmock')
 vmem_block_tests = executable(
     'vmem_block_tests',
     sources: [

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -8,7 +8,7 @@ if not meson.is_subproject()
     gmock_lib = static_library('gmock', install: false) 
 endif
 
-executable(
+vmem_block_tests = executable(
     'vmem_block_tests',
     sources: [
         'vmem_block_tests.cpp',
@@ -17,3 +17,5 @@ executable(
     include_directories : param_inc,
     link_with : param_lib
 )
+
+test('vmem_block_tests', vmem_block_tests)

--- a/tests/vmem_block_tests.cpp
+++ b/tests/vmem_block_tests.cpp
@@ -24,11 +24,11 @@ VMEM_DEFINE_BLOCK_CACHE(emmc_cache_reg2, EMMC_BLOCK_SIZE * 10);
 VMEM_DEFINE_BLOCK_CACHE(emmc_cache_reg3, EMMC_BLOCK_SIZE * 2);
 VMEM_DEFINE_BLOCK_CACHE(emmc_cache_reg4, EMMC_BLOCK_SIZE * 1);
 
-VMEM_DEFINE_BLOCK_REGION(stfw0, "stfw0", 0x0 + (0 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x10000000, emmc, emmc_cache_reg0);
-VMEM_DEFINE_BLOCK_REGION(stfw1, "stfw1", 0x0 + (1 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x10A00000, emmc, emmc_cache_reg1);
-VMEM_DEFINE_BLOCK_REGION(stfw2, "stfw2", 0x0 + (2 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x11400000, emmc, emmc_cache_reg2);
-VMEM_DEFINE_BLOCK_REGION(stfw3, "stfw3", 0x0 + (3 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x11E00000, emmc, emmc_cache_reg3);
-VMEM_DEFINE_BLOCK_REGION(stfw4, "stfw4", 0x0 + (4 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x12800000, emmc, emmc_cache_reg4);
+VMEM_DEFINE_BLOCK_REGION(stfw0, "stfw0", 0x0 + (0 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x1000000000ULL + (0 * STFW_FIFO_SIZE), emmc, emmc_cache_reg0);
+VMEM_DEFINE_BLOCK_REGION(stfw1, "stfw1", 0x0 + (1 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x1000000000ULL + (1 * STFW_FIFO_SIZE), emmc, emmc_cache_reg1);
+VMEM_DEFINE_BLOCK_REGION(stfw2, "stfw2", 0x0 + (2 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x1000000000ULL + (2 * STFW_FIFO_SIZE), emmc, emmc_cache_reg2);
+VMEM_DEFINE_BLOCK_REGION(stfw3, "stfw3", 0x0 + (3 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x1000000000ULL + (3 * STFW_FIFO_SIZE), emmc, emmc_cache_reg3);
+VMEM_DEFINE_BLOCK_REGION(stfw4, "stfw4", 0x0 + (4 * STFW_FIFO_SIZE), STFW_FIFO_SIZE, 0x1000000000ULL + (4 * STFW_FIFO_SIZE), emmc, emmc_cache_reg4);
 
 #define TEST_BUFFER_SIZE 10240
 #define TEST_BUFFER_OFFSET 78
@@ -88,8 +88,8 @@ TEST(vmem_block, upload_random_download_compare) {
     generate_random_data(&write_buffer[0], TEST_BUFFER_SIZE);
 
     // 2. Generate an empty "eMMC"
-    g_emmc_data_ptr = &g_emmc_data_write[STFW_FIFO_SIZE * 3];
-    memset(g_emmc_data_ptr, 0, STFW_FIFO_SIZE);
+    g_emmc_data_ptr = &g_emmc_data_write[0];
+    memset(g_emmc_data_ptr, 0, EMMC_SIZE);
 
     // 3. Write the random test buffer to the empty "eMMC"
     for (offset=0;offset<TEST_BUFFER_SIZE;offset+=TEST_WRITE_CHUNK_SIZE) {
@@ -108,7 +108,7 @@ TEST(vmem_block, upload_random_download_compare) {
     vmem_block_flush(&vmem_stfw3);
 
     // 5. Verify that the data was written correctly to the "eMMC"
-    EXPECT_TRUE( 0 == memcmp(&write_buffer[0], g_emmc_data_ptr, TEST_BUFFER_SIZE) );
+    EXPECT_TRUE( 0 == memcmp(&write_buffer[0], &g_emmc_data_ptr[STFW_FIFO_SIZE * 3], TEST_BUFFER_SIZE) );
 
     // 6. Clear out the readback buffer
     memset(&read_buffer[0], 0 , TEST_BUFFER_SIZE);
@@ -144,8 +144,8 @@ TEST(vmem_block, upload_random_download_compare_at_offset) {
     generate_random_data(&write_buffer[0], TEST_BUFFER_SIZE);
 
     // 2. Generate an empty "eMMC"
-    g_emmc_data_ptr = &g_emmc_data_write[STFW_FIFO_SIZE * 3];
-    memset(g_emmc_data_ptr, 0, STFW_FIFO_SIZE);
+    g_emmc_data_ptr = &g_emmc_data_write[0];
+    memset(g_emmc_data_ptr, 0, EMMC_SIZE);
 
     // 3. Write the random test buffer to the empty "eMMC"
     for (offset=0;offset<TEST_BUFFER_SIZE;offset+=TEST_WRITE_CHUNK_SIZE) {
@@ -164,7 +164,7 @@ TEST(vmem_block, upload_random_download_compare_at_offset) {
     vmem_block_flush(&vmem_stfw3);
 
     // 5. Verify that the data was written correctly to the "eMMC"
-    EXPECT_TRUE( 0 == memcmp(&write_buffer[0], &g_emmc_data_ptr[TEST_BUFFER_OFFSET], TEST_BUFFER_SIZE) );
+    EXPECT_TRUE( 0 == memcmp(&write_buffer[0], &g_emmc_data_ptr[STFW_FIFO_SIZE * 3 + TEST_BUFFER_OFFSET], TEST_BUFFER_SIZE) );
 
     // 6. Clear out the readback buffer
     memset(&read_buffer[0], 0 , TEST_BUFFER_SIZE);

--- a/tests/vmem_block_tests.cpp
+++ b/tests/vmem_block_tests.cpp
@@ -88,8 +88,8 @@ TEST(vmem_block, upload_random_download_compare) {
     generate_random_data(&write_buffer[0], TEST_BUFFER_SIZE);
 
     // 2. Generate an empty "eMMC"
-    g_emmc_data_ptr = &g_emmc_data_write[0];
-    memset(g_emmc_data_ptr, 0, EMMC_SIZE);
+    g_emmc_data_ptr = &g_emmc_data_write[STFW_FIFO_SIZE * 3];
+    memset(g_emmc_data_ptr, 0, STFW_FIFO_SIZE);
 
     // 3. Write the random test buffer to the empty "eMMC"
     for (offset=0;offset<TEST_BUFFER_SIZE;offset+=TEST_WRITE_CHUNK_SIZE) {
@@ -105,7 +105,7 @@ TEST(vmem_block, upload_random_download_compare) {
     }
 
     // 4. Flush any cached data to the "eMMC"
-    vmem_block_flush(&vmem_stfw0);
+    vmem_block_flush(&vmem_stfw3);
 
     // 5. Verify that the data was written correctly to the "eMMC"
     EXPECT_TRUE( 0 == memcmp(&write_buffer[0], g_emmc_data_ptr, TEST_BUFFER_SIZE) );
@@ -144,8 +144,8 @@ TEST(vmem_block, upload_random_download_compare_at_offset) {
     generate_random_data(&write_buffer[0], TEST_BUFFER_SIZE);
 
     // 2. Generate an empty "eMMC"
-    g_emmc_data_ptr = &g_emmc_data_write[0];
-    memset(g_emmc_data_ptr, 0, EMMC_SIZE);
+    g_emmc_data_ptr = &g_emmc_data_write[STFW_FIFO_SIZE * 3];
+    memset(g_emmc_data_ptr, 0, STFW_FIFO_SIZE);
 
     // 3. Write the random test buffer to the empty "eMMC"
     for (offset=0;offset<TEST_BUFFER_SIZE;offset+=TEST_WRITE_CHUNK_SIZE) {
@@ -161,7 +161,7 @@ TEST(vmem_block, upload_random_download_compare_at_offset) {
     }
 
     // 4. Flush any cached data to the "eMMC"
-    vmem_block_flush(&vmem_stfw0);
+    vmem_block_flush(&vmem_stfw3);
 
     // 5. Verify that the data was written correctly to the "eMMC"
     EXPECT_TRUE( 0 == memcmp(&write_buffer[0], &g_emmc_data_ptr[TEST_BUFFER_OFFSET], TEST_BUFFER_SIZE) );


### PR DESCRIPTION
From now on, VMEM API is 64bits, breaking earlier ABI. 
New user code can use the fact that this macro is defined (its value is not relevant, just the fact that it is defined)
to check that the libparam version included (typically through convoluted dependency paths) does support the 64-bits API
and #error if it doesnt.

In this PR, I also introduce a github action to build + unit test (right now, there are not a lot of tests...).