### PR TITLE
Set param timestamp in queue apply only for remote params

### DIFF
--- a/src/param/param_queue.c
+++ b/src/param/param_queue.c
@@ -92,7 +92,9 @@ int param_queue_apply(param_queue_t *queue, int apply_local, int from) {
 					param_enter_critical();
 			}
 
-			*param->timestamp = timestamp;
+			if (param->node != 0) {
+				*param->timestamp = timestamp;
+			}
 
 			param_deserialize_from_mpack_to_param(NULL, queue, param, offset, &reader);
 		} else {


### PR DESCRIPTION
@johandc How about this on the server-side, when doing push_queue