### PR TITLE
PLT-289 Refactor param_t to have node as pointer

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -92,7 +92,7 @@ typedef struct param_s {
 
 	/* Parameter declaration */
 	uint16_t id;
-	uint16_t node;
+	uint16_t * node;
 	param_type_e type;
 	uint32_t mask;
 	char *name;
@@ -135,11 +135,12 @@ typedef struct param_s {
 #define PARAM_DEFINE_STATIC_RAM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
+	uint16_t _node_##_name = 0; \
 	__attribute__((section("param"))) \
 	__attribute__((used)) \
 	param_t _name = { \
 		.vmem = NULL, \
-		.node = 0, \
+		.node = &_node_##_name, \
 		.id = _id, \
 		.type = _type, \
 		.name = #_name, \
@@ -157,10 +158,11 @@ typedef struct param_s {
 #define PARAM_DEFINE_STATIC_VMEM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _vmem_name, _vmem_addr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
+	uint16_t _node_##_name = 0; \
 	__attribute__((section("param"))) \
 	__attribute__((used)) \
 	param_t _name = { \
-		.node = 0, \
+		.node = &_node_##_name, \
 		.id = _id, \
 		.type = _type, \
 		.name = #_name, \
@@ -178,7 +180,7 @@ typedef struct param_s {
 
 #define PARAM_REMOTE_NODE_IGNORE 16382
 
-#define PARAM_DEFINE_REMOTE(_name, _node, _id, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
+#define PARAM_DEFINE_REMOTE(_id, _name, _node, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
 	__attribute__((section("param"))) \
@@ -201,8 +203,9 @@ typedef struct param_s {
 #define PARAM_DEFINE_REMOTE_DYNAMIC(_id, _name, _node, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
+	uint16_t _node_##_name = _node; \
 	param_t _name = { \
-		.node = _node, \
+		.node = &_node_##_name, \
 		.id = _id, \
 		.type = _type, \
 		.array_size = _array_count < 1 ? 1 : _array_count, \

--- a/src/param/param_client.c
+++ b/src/param/param_client.c
@@ -181,7 +181,7 @@ int param_pull_single(param_t *param, int offset, uint8_t prio, int verbose, int
 
 	packet->length = queue.used + 2;
 	packet->id.pri = prio;
-	return param_transaction(packet, host, timeout, param_transaction_callback_pull, verbose, version, NULL);
+	return param_transaction(packet, *param->node, timeout, param_transaction_callback_pull, verbose, version, NULL);
 }
 
 

--- a/src/param/param_queue.c
+++ b/src/param/param_queue.c
@@ -185,7 +185,7 @@ void param_queue_print(param_queue_t *queue) {
 		if (param) {
 			printf("cmd add ");
 			if (param->node > 0) {
-				printf("-n %d ", param->node);
+				printf("-n %d ", *param->node);
 			}
 			printf("%s", param->name);
 			if (offset >= 0) {

--- a/src/param/param_serializer.c
+++ b/src/param/param_serializer.c
@@ -21,7 +21,7 @@
 #include <mpack/mpack.h>
 
 static inline uint16_t param_get_short_id(param_t * param, unsigned int isarray, unsigned int reserved) {
-	uint16_t node = param->node;
+	uint16_t node = *param->node;
 	return (node << 11) | ((isarray & 0x1) << 10) | ((reserved & 0x1) << 2) | ((param->id) & 0x1FF);
 }
 
@@ -51,7 +51,7 @@ void param_serialize_id(mpack_writer_t *writer, param_t *param, int offset, para
 
 	} else {
 
-		int node = param->node;
+		int node = *param->node;
 		uint32_t timestamp = *param->timestamp;
 		int array_flag = (offset >= 0) ? 1 : 0;
 		int node_flag = (queue->last_node != node) ? 1 : 0;

--- a/src/param/param_string.c
+++ b/src/param/param_string.c
@@ -299,7 +299,7 @@ void param_print_file(FILE* file, param_t * param, int offset, int nodes[], int 
 
 	/* Node/ID */
 	if (verbose >= 1) {
-		fprintf(file, " %3u:%-2u", param->id, param->node);
+		fprintf(file, " %3u:%-2u", param->id, *param->node);
 	}
 
 	/* Name */

--- a/src/vmem/vmem_server.c
+++ b/src/vmem/vmem_server.c
@@ -289,7 +289,7 @@ static void rparam_list_handler(csp_conn_t * conn)
 		memset(packet->data, 0, 256);
 
 		param_transfer3_t * rparam = (void *) packet->data;
-		int node = param->node;
+		int node = *param->node;
 		rparam->id = htobe16(param->id);
 		rparam->node = htobe16(node);
 		rparam->type = param->type;


### PR DESCRIPTION
Tested on embedded platform. But will introduce a breaking change for anyone who uses remote parameters, or otherwise inspects the .node field of the param_t struct.