### PR TITLE
Feature/PLT-309 Extend VMEM server with possibility to bind external functions to specific request types

### DIFF
--- a/include/vmem/vmem_server.h
+++ b/include/vmem/vmem_server.h
@@ -8,6 +8,8 @@
 #ifndef LIB_PARAM_INCLUDE_VMEM_VMEM_SERVER_H_
 #define LIB_PARAM_INCLUDE_VMEM_VMEM_SERVER_H_
 
+#include <sys/queue.h>
+
 #include <csp/csp.h>
 #include <vmem/vmem.h>
 
@@ -24,12 +26,15 @@ typedef enum {
 	VMEM_SERVER_BACKUP,
 	VMEM_SERVER_UNLOCK,
 	VMEM_SERVER_CALCULATE_CRC32,
+
+	VMEM_SERVER_USER_TYPES = 0x80,
 } vmem_request_type;
 
 typedef struct {
 	uint8_t version;
 	uint8_t type;
 	union {
+		uint8_t body[0];
 		struct {
 			uint32_t address;
 			uint32_t length;
@@ -75,7 +80,35 @@ typedef struct {
 	char name[16+1];
 } __attribute__((packed)) vmem_list3_t;
 
+typedef int vmem_handler_t(csp_conn_t *conn, csp_packet_t *packet, void *context);
+typedef struct vmem_handler_obj_s {
+	uint8_t type;
+	void *context;
+	vmem_handler_t *handler;
+	SLIST_ENTRY( vmem_handler_obj_s ) list;
+} vmem_handler_obj_t;
+
 void vmem_server_handler(csp_conn_t * conn);
 void vmem_server_loop(void * param);
+
+/**
+ * @brief Register a handler for a specific VMEM request type
+ * 
+ * Use this method for registering a handler to be called for a specific
+ * type of VMEM request. The handler will be called with the request type,
+ * the connection and packet as arguments, and the context pointer as the
+ * fourth argument.
+ * 
+ * The caller must supply the memory for the handler object, which will be
+ * inserted into a list of handlers. The handler object must be kept alive
+ * until the handler is unregistered.
+ * 
+ * @param type The VMEM request type to bind the handler to
+ * @param func A pointer to the handler function which gets called
+ * @param obj Pointer to the handler object supplied by the caller
+ * @param context A pointer to the context data to be passed to the handler
+ * @return int 0=success, -1=error
+ */
+int vmem_server_bind_type(uint8_t type, vmem_handler_t *func, vmem_handler_obj_t *obj, void *context);
 
 #endif /* LIB_PARAM_INCLUDE_VMEM_VMEM_SERVER_H_ */


### PR DESCRIPTION
Introduced a VMEM request type plug-in mechanism to be used to extend the VMEM server with new features which not necessarily belongs to VMEM in public domain.

Now one can use the `vmem_server_bind_type()` method for registering a handler function which will be called in the VMEM server context for a particular VMEM request. These VMEM requests Are all request ID's with bit-7 set to '1' to indicate USER request.

The handler will be registered in a linked list which will be maintained by the VMEM server it self. The memory used for each handler must be handled by  the calling module (user), so that the VMEM server does not require configuration prior to compilation.