### PR TITLE
Place *pointers* to param_t in "param" section

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -136,10 +136,10 @@ typedef struct param_s {
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
 	uint16_t _node_##_name = 0; \
-	__attribute__((section("param"))) \
+	__attribute__((section("param_data"))) \
 	__attribute__((used, no_reorder)) \
 	param_t _name = { \
-		.vmem = NULL, \
+	   .vmem = NULL, \
 		.node = &_node_##_name, \
 		.id = _id, \
 		.type = _type, \
@@ -153,16 +153,18 @@ typedef struct param_s {
 		.addr = (void *)(_physaddr), \
 		.vaddr = 0, \
 		.docstr = _docstr, \
-	}
+	}; \
+	__attribute__((section("param"))) \
+	const param_t * const ___##_name = &_name;
 
 #define PARAM_DEFINE_STATIC_VMEM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _vmem_name, _vmem_addr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
 	uint16_t _node_##_name = 0; \
-	__attribute__((section("param"))) \
+	__attribute__((section("param_data"))) \
 	__attribute__((used, no_reorder)) \
 	param_t _name = { \
-		.node = &_node_##_name, \
+	   .node = &_node_##_name, \
 		.id = _id, \
 		.type = _type, \
 		.name = #_name, \
@@ -176,14 +178,16 @@ typedef struct param_s {
 		.vaddr = _vmem_addr, \
 		.vmem = &vmem_##_vmem_name, \
 		.docstr = _docstr, \
-	}
+	}; \
+	__attribute__((section("param"))) \
+	const param_t * const ___##_name = &_name;
 
 #define PARAM_REMOTE_NODE_IGNORE 16382
 
 #define PARAM_DEFINE_REMOTE(_id, _name, _nodeaddr, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \
 	uint32_t _timestamp_##_name = 0; \
-	__attribute__((section("param"))) \
+	__attribute__((section("param_data"))) \
 	__attribute__((used, no_reorder)) \
 	param_t _name = { \
 		.node = _nodeaddr, \
@@ -198,7 +202,9 @@ typedef struct param_s {
 		.vmem = NULL, \
 		.timestamp = &_timestamp_##_name, \
 		.docstr = _docstr, \
-	};
+	}; \
+	__attribute__((section("param"))) \
+	const param_t * const ___##_name = &_name;
 
 #define PARAM_DEFINE_REMOTE_DYNAMIC(_id, _name, _node, _type, _array_count, _array_step, _flags, _physaddr, _docstr) \
 	; /* Catch const param defines */ \

--- a/include/param/param_list.h
+++ b/include/param/param_list.h
@@ -18,6 +18,7 @@ extern "C" {
 typedef struct param_list_iterator_s {
 	int phase;							// Hybrid iterator has multiple phases (0 == Static, 1 == Dynamic List)
 	param_t * element;
+	param_t ** element_addr;            // Only used for "static" phase parameters above
 } param_list_iterator;
 
 param_t * param_list_iterate(param_list_iterator * iterator);

--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -28,37 +28,16 @@
 #include <sys/queue.h>
 #endif
 
-/**
- * The storage size (i.e. how closely two param_t structs are packed in memory)
- * varies from platform to platform (in example on x64 and arm32). This macro
- * defines two param_t structs and saves the storage size in a define.
- * The linker may also put padding bytes between param_t's (even in the same section),
- * but it appears that the same padding is added to the parameters below, so the macro will account for it.
- * In addition, Newer GCC versions (gcc 13.3.0 and arm-none-eabi-gcc 13.2.1, common for Ubuntu 24.04)
- * will put symbols in reverse order (when compared with gcc 11.4 and arm-none-eabi-gcc 10.3.1, common for Ubuntu 22.04).
- * So that necessitates `__attribute__((no_reorder))`, so the size doesn't become negative.
- * `__attribute__((no_reorder))` is preferred over c_args '-fno-toplevel-reorder',
- * as it doesn't require the user to modify their usage of libparam.
- */
-#ifndef PARAM_STORAGE_SIZE
-__attribute__((no_reorder))
-const param_t param_size_set0;
-__attribute__((no_reorder))
-const param_t param_size_set1;
-#define PARAM_STORAGE_SIZE ((intptr_t) &param_size_set1 - (intptr_t) &param_size_set0)
-#endif
-
 #ifdef PARAM_HAVE_SYS_QUEUE
 static SLIST_HEAD(param_list_head_s, param_s) param_list_head = {};
 #endif
 
+__attribute__((weak)) extern param_t *__start_param;
+__attribute__((weak)) extern param_t *__stop_param;
 uint8_t param_is_static(param_t * param) {
 
-	__attribute__((weak)) extern param_t __start_param;
-	__attribute__((weak)) extern param_t __stop_param;
-
 	if ((&__start_param != NULL) && (&__start_param != &__stop_param)) {
-		if (param >= &__start_param && param < &__stop_param)
+		if (param >= __start_param && param < __stop_param)
 			return 1;
 	}
 	return 0;
@@ -66,20 +45,14 @@ uint8_t param_is_static(param_t * param) {
 
 param_t * param_list_iterate(param_list_iterator * iterator) {
 
-	/**
-	 * GNU Linker symbols. These will be autogenerate by GCC when using
-	 * __attribute__((section("param"))
-	 */
-	__attribute__((weak)) extern param_t __start_param;
-	__attribute__((weak)) extern param_t __stop_param;
-
 	/* First element */
 	if (iterator->element == NULL) {
 
 		/* Static */
 		if ((&__start_param != NULL) && (&__start_param != &__stop_param)) {
 			iterator->phase = 0;
-			iterator->element = &__start_param;
+			iterator->element = __start_param;
+			iterator->element_addr = &__start_param;
 		} else {
 			iterator->phase = 1;
 #ifdef PARAM_HAVE_SYS_QUEUE
@@ -89,19 +62,21 @@ param_t * param_list_iterate(param_list_iterator * iterator) {
 	} else {
 		if(iterator->phase == 0){
 			/* Increment in static memory */
-			iterator->element = (param_t *)(intptr_t)((char *)iterator->element + PARAM_STORAGE_SIZE);
+			iterator->element_addr = iterator->element_addr + 1;
+			iterator->element = *iterator->element_addr;
 		}
 #ifdef PARAM_HAVE_SYS_QUEUE
 		else if(iterator->phase == 1){
-			iterator->element = SLIST_NEXT(iterator->element, next);
+			iterator->element = SLIST_NEXT((iterator->element), next);
 		}
 #endif
 	}
 
 	if(iterator->phase == 0){
-		while(iterator->element < &__stop_param){
+		while(iterator->element_addr != &__stop_param){
 			if (iterator->element->mask & PM_REMOTE && *iterator->element->node == 0){
-				iterator->element = (param_t *)(intptr_t)((char *)iterator->element + PARAM_STORAGE_SIZE);
+				iterator->element_addr = iterator->element_addr + 1;
+				iterator->element = *iterator->element_addr;
 				continue;
 			}
 			return iterator->element;


### PR DESCRIPTION
- introduce a new linker section "param_data" where param_t objects will be placed
- update the PARAM_DEFINE_* macros to place a *pointer* to the param_t objects defined above
- place these pointers the "param" section
- update the param_list_iterate to run over the *pointers* instead of the *param_t* objects in the "param" section

This has 2 benefits:
- the iteration code no longer need to rely on knowing the platform/compiler/... size and alignment contraints of the "param_t" type, we just "++" a pointer to those
- the actual param_t data now lives in the new "param_data" section, meaning it is now truely read-only, saving som RAM and code (it seems to peel about 8.5 Kb off the .text section in C21 builds...)

Major advantage: *no* user code needs updating! The code has been tested on OBC-P4, REWL and CSH