### PR TITLE
Added VMEM request hdr_t type.

### DIFF
--- a/include/vmem/vmem_server.h
+++ b/include/vmem/vmem_server.h
@@ -33,6 +33,16 @@ typedef enum {
 typedef struct {
 	uint8_t version;
 	uint8_t type;
+} __attribute__((packed)) vmem_request_hdr_t;
+
+typedef struct {
+	union {
+		struct {
+			uint8_t version;
+			uint8_t type;
+		};
+		vmem_request_hdr_t hdr;
+	};
 	union {
 		uint8_t body[0];
 		struct {


### PR DESCRIPTION
We have extended the VMEM module with a way to dynamically register callbacks with the VMEM server for particular VMEM request types. This opens up the need for having a more modular structure of the `vmem_request_t`. This PR suggest a split of the header part and the actual data body part of the `vmem_request_t`. This results in a `vmem_request_hdr_t` which is put together with the original header as a union, for backward compatibility.

This will make it somewhat easier to define user/custom VMEM request types outside the VMEM server module and reuse the `vmem_request_hdr_t`.