### PR TITLE
Upload return len

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -10,6 +10,8 @@
 
 #include <stdint.h>
 #include <vmem/vmem.h>
+#include <param/param_error.h>
+
 
 #include "libparam.h"
 

--- a/include/param/param_error.h
+++ b/include/param/param_error.h
@@ -1,0 +1,7 @@
+#pragma once
+
+#define PARAM_ERR_NONE		0		/**< No error */
+#define PARAM_ERR_NOMEM		-400		/**< Not enough memory */
+#define PARAM_ERR_INVAL		-401		/**< Invalid argument */
+#define PARAM_ERR_NOTSUP	-402		/**< Operation not supported */
+

--- a/include/vmem/vmem_client.h
+++ b/include/vmem/vmem_client.h
@@ -3,7 +3,23 @@
 #include <stdint.h>
 #include <vmem/vmem_server.h>
 
-int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp);
+/**
+ * @brief Download data from remote vmem server at vmem address
+ * 
+ * Use this function for downloading data from remote node.
+ * 
+ * @param node The remote node to upload to
+ * @param timeout Timeout for download
+ * @param address VMEM address to download from on remote
+ * @param dataout Pointer to data buffer
+ * @param length The length in bytes to download into dataout buffer
+ * @param use_rdp Set flag to use RDP connection
+ * @param version Protocol version to use be used. Use 2 for 64-bit VMEM address otherwise 32-bit is assumed
+ * @param verbosity Set verbosity level: 0 for silent, 1 for final summary, 2 = for detailed progress
+ * @return On success, the total number of bytes successfully uploaded
+ * @return On error, a negative value is returned to indicate the specific error
+ */
+ssize_t vmem_download(uint16_t node, uint32_t timeout, uint64_t address, char * dataout, uint32_t length, int use_rdp, int version, int verbosity);
 
 /**
  * @brief Upload data to remote vmem server at vmem address
@@ -14,12 +30,14 @@ int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char
  * @param timeout Timeout for upload
  * @param address VMEM address to upload to on remote
  * @param datain Pointer to data to upload
- * @param[in,out] lengthio On input, points to the desired upload size; on output, is updated with the actual size uploaded
+ * @param length The length in bytes of the data passed in
+ * @param use_rdp Set flag to use RDP connection
  * @param version Protocol version to use be used. Use 2 for 64-bit VMEM address otherwise 32-bit is assumed
- * @param verbose Set verbosity level: 0 for silent, 1 for final summary, 2 = for detailed progress
- * @return int 0=success, -1=error
+ * @param verbosity Set verbosity level: 0 for silent, 1 for final summary, 2 = for detailed progress
+ * @return On success, the total number of bytes successfully downloaded
+ * @return On error, a negative value is returned to indicate the specific error
  */
-int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t *lengthio, int version, int verbose);
+ssize_t vmem_upload(uint16_t node, uint32_t timeout, uint64_t address, const char * datain, uint32_t size, int use_rdp, int version, int verbosity);
 void vmem_client_list(int node, int timeout, int version);
 int vmem_client_find(int node, int timeout, void * dataout, int version, char * name, int namelen);
 int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore);

--- a/include/vmem/vmem_client.h
+++ b/include/vmem/vmem_client.h
@@ -4,7 +4,22 @@
 #include <vmem/vmem_server.h>
 
 int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp);
-int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t length, int version);
+
+/**
+ * @brief Upload data to remote vmem server at vmem address
+ * 
+ * Use this function for uploading data to remote node.
+ * 
+ * @param node The remote node to upload to
+ * @param timeout Timeout for upload
+ * @param address VMEM address to upload to on remote
+ * @param datain Pointer to data to upload
+ * @param[in,out] lengthio On input, points to the desired upload size; on output, is updated with the actual size uploaded
+ * @param version Protocol version to use be used. Use 2 for 64-bit VMEM address otherwise 32-bit is assumed
+ * @param verbose Set verbosity level: 0 for silent, 1 for final summary, 2 = for detailed progress
+ * @return int 0=success, -1=error
+ */
+int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t *lengthio, int version, int verbose);
 void vmem_client_list(int node, int timeout, int version);
 int vmem_client_find(int node, int timeout, void * dataout, int version, char * name, int namelen);
 int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore);

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -5,12 +5,15 @@
  *      Author: johan
  */
 
+#include <stdint.h>
 #include <stdio.h>
 #include <csp/arch/csp_time.h>
 #include <sys/types.h>
 #include <unistd.h>
 
 #include <vmem/vmem_client.h>
+#include <param/param_error.h>
+#include "csp/csp_error.h"
 
 static int abort = 0;
 
@@ -18,12 +21,13 @@ void vmem_client_abort(void) {
 	abort = 1;
 }
 
-int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp)
-{
+ssize_t vmem_download(uint16_t node, uint32_t timeout, uint64_t address, char * dataout, uint32_t length, int use_rdp, int version, int verbosity) {
 
 	if((address > UINT32_MAX) && version != 2){
-		printf("  Error: Address out of range 64-bit addresses require version 2\n");
-		return -1;
+		if(verbosity > 0){
+			printf("  Error: Address out of range 64-bit addresses require version 2\n");
+		}
+		return PARAM_ERR_INVAL;
 	}
 
 	uint32_t time_begin = csp_get_ms();
@@ -35,12 +39,16 @@ int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char
 		opts |= CSP_O_RDP;
 	}
 	csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, opts);
-	if (conn == NULL)
-		return -1;
+	if (conn == NULL){
+		if(verbosity > 0) {
+			printf("  Connection could not be established\n");
+		}
+		return CSP_ERR_TIMEDOUT;
+	}
 
 	csp_packet_t * packet = csp_buffer_get(sizeof(vmem_request_t));
 	if (packet == NULL)
-		return -1;
+		return CSP_ERR_NOMEM;
 
 	vmem_request_t * request = (void *) packet->data;
 	request->version = version;
@@ -84,13 +92,15 @@ int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char
 			break;
 		}
 
-		if (dotcount % 32 == 0)
-			printf("  ");
-		printf(".");
-		fflush(stdout);
-		dotcount++;
-		if (dotcount % 32 == 0)
-			printf(" - %.0f K\n", (count / 1024.0));
+		if(verbosity > 1) {
+			if (dotcount % 32 == 0)
+				printf("  ");
+			printf(".");
+			fflush(stdout);
+			dotcount++;
+			if (dotcount % 32 == 0)
+				printf(" - %.0f K\n", (count / 1024.0));
+		}
 
 		/* Put data */
 		memcpy((void *) ((intptr_t) dataout + count), packet->data, packet->length);
@@ -101,43 +111,50 @@ int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char
 		csp_buffer_free(packet);
 	}
 
-	printf(" - %.0f K\n", (count / 1024.0));
+	if(verbosity > 1) {
+		printf(" - %.0f K\n", (count / 1024.0));
+	}
 
 	csp_close(conn);
 
 	uint32_t time_total = csp_get_ms() - time_begin;
 
-	printf("  Downloaded %u bytes in %.03f s at %u Bps\n", (unsigned int) count, time_total / 1000.0, (unsigned int) (count / ((float)time_total / 1000.0)) );
+	if(verbosity > 0) {
+		printf("  Downloaded %u bytes in %.03f s at %u Bps\n", (unsigned int) count, time_total / 1000.0, (unsigned int) (count / ((float)time_total / 1000.0)) );
+	}
 
 	return count;
 
 }
 
-int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t * lengthio, int version, int verbose) {
-
+ssize_t vmem_upload(uint16_t node, uint32_t timeout, uint64_t address, const char * datain, uint32_t length, int use_rdp, int version, int verbosity) {
 
 	if((address > UINT32_MAX) && version != 2){
-		printf("  Error: Address out of range 64-bit addresses require version 2\n");
-		return -1;
+		if(verbosity > 0){
+			printf("  Error: Address out of range 64-bit addresses require version 2\n");
+		}
+		return PARAM_ERR_INVAL;
 	}
 
 	uint32_t time_begin = csp_get_ms();
 	abort = 0;
 
 	/* Establish RDP connection */
-	csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, CSP_O_RDP | CSP_O_CRC32);
+	uint32_t opts = CSP_O_CRC32;
+	if (use_rdp) {
+		opts |= CSP_O_RDP;
+	}
+	csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, opts);
 	if (conn == NULL) {
-		if(verbose > 0) {
-			printf("Connection could not be established\n");
+		if(verbosity > 0) {
+			printf("  Connection could not be established\n");
 		}
-		*lengthio = 0;
-		return -1;
+		return CSP_ERR_TIMEDOUT;
 	}
 
 	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL) {
-		*lengthio = 0;
-		return -2;
+		return CSP_ERR_NOMEM;
 	}
 
 	vmem_request_t * request = (void *) packet->data;
@@ -146,10 +163,10 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	if (version == 2) {
 		request->data2.address = htobe64(address);
-		request->data2.length = htobe32(*lengthio);
+		request->data2.length = htobe32(length);
 	} else {
 		request->data.address = htobe32((uint32_t)(address & 0x00000000FFFFFFFFULL));
-		request->data.length = htobe32(*lengthio);
+		request->data.length = htobe32(length);
 	}
 	packet->length = sizeof(vmem_request_t);
 
@@ -158,14 +175,13 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	uint32_t count = 0;
 	int dotcount = 0;
-	while((count < *lengthio) && csp_conn_is_active(conn)) {
+	while((count < length) && csp_conn_is_active(conn)) {
 
 		if (abort) {
-			csp_buffer_free(packet);
 			break;
 		}
 
-		if(verbose > 1) {
+		if(verbosity > 1) {
 			if (dotcount % 32 == 0)
 				printf("  ");
 			printf(".");
@@ -177,7 +193,10 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 		/* Prepare packet */
 		csp_packet_t * packet = csp_buffer_get(0);
-		packet->length = VMEM_MIN(VMEM_SERVER_MTU, *lengthio - count);
+		if(packet == NULL) {
+			break;
+		}
+		packet->length = VMEM_MIN(VMEM_SERVER_MTU, length - count);
 
 		/* Copy data */
 		memcpy(packet->data, (void *) ((intptr_t) datain + count), packet->length);
@@ -189,7 +208,7 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	}
 
-	if(verbose > 1) {
+	if(verbosity > 1) {
 		printf(" - %.0f K\n", (count / 1024.0));
 	}
 
@@ -197,16 +216,11 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	uint32_t time_total = csp_get_ms() - time_begin;
 
-	if(verbose > 0) {
+	if(verbosity > 0) {
 		printf("  Uploaded %"PRIu32" bytes in %.03f s at %"PRIu32" Bps\n", count, time_total / 1000.0, (uint32_t)(count / ((float)time_total / 1000.0)) );
 	}
 
-	if(*lengthio != count){
-		*lengthio = count;
-		return -3;
-	}
-
-	return 0;
+	return count;
 }
 
 static csp_packet_t * vmem_client_list_get(int node, int timeout, int version) {

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -115,7 +115,7 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 	/* Establish RDP connection */
 	csp_conn_t * conn = csp_connect(CSP_PRIO_HIGH, node, VMEM_PORT_SERVER, timeout, CSP_O_RDP | CSP_O_CRC32);
 	if (conn == NULL) {
-		if(verbose == 1) {
+		if(verbose > 0) {
 			printf("Connection could not be established\n");
 		}
 		*lengthio = 0;
@@ -125,7 +125,7 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 	csp_packet_t * packet = csp_buffer_get(0);
 	if (packet == NULL) {
 		*lengthio = 0;
-		return -1;
+		return -2;
 	}
 
 	vmem_request_t * request = (void *) packet->data;
@@ -153,7 +153,7 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 			break;
 		}
 
-		if(verbose == 2) {
+		if(verbose > 1) {
 			if (dotcount % 32 == 0)
 				printf("  ");
 			printf(".");
@@ -177,7 +177,7 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	}
 
-	if(verbose == 2) {
+	if(verbose > 1) {
 		printf(" - %.0f K\n", (count / 1024.0));
 	}
 
@@ -185,11 +185,15 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 
 	uint32_t time_total = csp_get_ms() - time_begin;
 
-	if(verbose == 1) {
+	if(verbose > 0) {
 		printf("  Uploaded %"PRIu32" bytes in %.03f s at %"PRIu32" Bps\n", count, time_total / 1000.0, (uint32_t)(count / ((float)time_total / 1000.0)) );
 	}
 
-	*lengthio = count;
+	if(*lengthio != count){
+		*lengthio = count;
+		return -3;
+	}
+
 	return 0;
 }
 

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -180,7 +180,6 @@ int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t
 		unsigned int window_size = 0;
 		csp_rdp_get_opt(&window_size, NULL, NULL, NULL, NULL, NULL);
 		printf("Upload didn't complete, suggested offset to resume: %"PRIu32"\n", count - ((window_size + 1) * VMEM_SERVER_MTU));
-		return -1;
 	} else {
 		printf("  Uploaded %"PRIu32" bytes in %.03f s at %"PRIu32" Bps\n", count, time_total / 1000.0, (uint32_t)(count / ((float)time_total / 1000.0)) );
 	}

--- a/src/vmem/vmem_client.c
+++ b/src/vmem/vmem_client.c
@@ -20,6 +20,12 @@ void vmem_client_abort(void) {
 
 int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char * dataout, int version, int use_rdp)
 {
+
+	if((address > UINT32_MAX) && version != 2){
+		printf("  Error: Address out of range 64-bit addresses require version 2\n");
+		return -1;
+	}
+
 	uint32_t time_begin = csp_get_ms();
 	abort = 0;
 
@@ -108,6 +114,12 @@ int vmem_download(int node, int timeout, uint64_t address, uint32_t length, char
 }
 
 int vmem_upload(int node, int timeout, uint64_t address, char * datain, uint32_t * lengthio, int version, int verbose) {
+
+
+	if((address > UINT32_MAX) && version != 2){
+		printf("  Error: Address out of range 64-bit addresses require version 2\n");
+		return -1;
+	}
 
 	uint32_t time_begin = csp_get_ms();
 	abort = 0;
@@ -358,6 +370,11 @@ int vmem_client_backup(int node, int vmem_id, int timeout, int backup_or_restore
 int vmem_client_calc_crc32(int node, int timeout, uint64_t address, uint32_t length, uint32_t * crc_out, int version) {
 
 	int res = -1;
+
+	if((address > UINT32_MAX) && version != 2){
+		printf("  Error: 64 bit address only supported in version 2\n");
+		return res;
+	}
 
 	uint32_t time_begin = csp_get_ms();
 


### PR DESCRIPTION
Align upload download API.
Added check for 64 bit address with version 1
Added a param_error.h to start making libparam a more coherent library.
Changed return values to ssize_t, not sure if we want to keep int or make it int64.
This is only necessary if we want to be able to return the count of the full 4GB possible upload and download length supported. 
ssize_t would work on 64 bit client, not on 32 bit.
Forcing int64 would fix this 