### PR TITLE
Include VMEM type update when downloading and updating existing param

### DIFF
--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -131,6 +131,7 @@ int param_list_add(param_t * item) {
 			param->type = item->type;
 			param->array_size = item->array_size;
 			param->array_step = item->array_step;
+			param->vmem->type = item->vmem->type;
 
 			if(param->name && item->name){
 				strcpy(param->name, item->name);


### PR DESCRIPTION
Found while running csh_conf after having loaded older param lists not defining VMEM type