### PR TITLE
Implemented a PM_HIDDEN parameter mask.

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -70,6 +70,8 @@ typedef enum {
 #define PM_PRIO3               (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 #define PM_PRIO_MASK           (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 
+#define PM_HIDDEN              (1 << 15) //! H: Hidden parameter 
+
 /* Reserved flags:
  * Lower 16 is parameter system, upper 16 are user flags  */
 #define PM_PARAM_FLAGS        0x0000FFFF //! Lower 16-bits are reserved for parameter system and major class flags

--- a/src/param/param_server.c
+++ b/src/param/param_server.c
@@ -168,6 +168,9 @@ static void param_serve_pull_request(csp_packet_t * request, int all, int versio
 		param_t * param;
 		param_list_iterator i = {};
 		while ((param = param_list_iterate(&i)) != NULL) {
+			if (param->mask & PM_HIDDEN) {
+				continue;
+			}
 			uint32_t include_mask = be32toh(ctx.request->data32[1]);
 			uint32_t exclude_mask = 0x00000000;
 			if (version >= 2) {

--- a/src/vmem/vmem_server.c
+++ b/src/vmem/vmem_server.c
@@ -338,6 +338,9 @@ static void rparam_list_handler(csp_conn_t * conn)
 	param_t * param;
 	param_list_iterator i = {};
 	while ((param = param_list_iterate(&i)) != NULL) {
+		if (param->mask & PM_HIDDEN) {
+			continue;
+		}
 		csp_packet_t * packet = csp_buffer_get(256);
 		if (packet == NULL)
 			break;


### PR DESCRIPTION
The PM_HIDDEN parameter mask will prevent list downloads and pull from returning parameters with that specific mask-bit set.