### PR TITLE
VMEM file: use file object directly instead of RAM buffer

### DIFF
--- a/include/vmem/vmem_file.h
+++ b/include/vmem/vmem_file.h
@@ -19,15 +19,14 @@
 
 #if __64BIT__
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr = (uint64_t)vmem_##name_in##_buf
+		.vaddr = (uint64_t)&vmem_##name_in##_driver
 #else
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr32 = (uint32_t)vmem_##name_in##_buf, \
+		.vaddr32 = (uint32_t)&vmem_##name_in##_driver, \
 		.vaddr_pad = 0
 #endif
 
 typedef struct {
-	void * physaddr;
 	char * filename;
 	FILE * stream;
 } vmem_file_driver_t;
@@ -37,9 +36,7 @@ void vmem_file_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t
 void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len);
 
 #define VMEM_DEFINE_FILE(name_in, strname, filename_in, size_in) \
-	uint8_t vmem_##name_in##_buf[size_in] = {}; \
 	static vmem_file_driver_t vmem_##name_in##_driver = { \
-		.physaddr = vmem_##name_in##_buf, \
 		.filename = filename_in, \
 	}; \
 	__attribute__((section("vmem"))) \
@@ -57,9 +54,7 @@ void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, ui
 	};
 
 #define VMEM_DEFINE_FILE_VADDR(name_in, strname, filename_in, size_in, fixed_vaddr) \
-	uint8_t vmem_##name_in##_buf[size_in] = {}; \
 	static vmem_file_driver_t vmem_##name_in##_driver = { \
-		.physaddr = vmem_##name_in##_buf, \
 		.filename = filename_in, \
 	}; \
 	__attribute__((section("vmem"))) \

--- a/include/vmem/vmem_file.h
+++ b/include/vmem/vmem_file.h
@@ -19,28 +19,38 @@
 
 #if __64BIT__
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr = (uint64_t)&vmem_##name_in##_driver
+		.vaddr = (uint64_t)&vmem_##name_in##_buf
 #else
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr32 = (uint32_t)&vmem_##name_in##_driver, \
+		.vaddr32 = (uint32_t)&vmem_##name_in##_buf, \
 		.vaddr_pad = 0
 #endif
 
 typedef struct {
+	void * physaddr;
 	char * filename;
 	FILE * stream;
 } vmem_file_driver_t;
 
+typedef struct {
+	const char * filename;
+	FILE * stream;
+} vmem_file_vaddr_driver_t;
+
 void vmem_file_init(const vmem_t * vmem);
 void vmem_file_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t len);
 void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len);
+void vmem_file_vaddr_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t len);
+void vmem_file_vaddr_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len);
 
 #define VMEM_DEFINE_FILE(name_in, strname, filename_in, size_in) \
+	uint8_t vmem_##name_in##_buf[size_in] = {}; \
 	static vmem_file_driver_t vmem_##name_in##_driver = { \
+		.physaddr = vmem_##name_in##_buf, \
 		.filename = filename_in, \
 	}; \
 	__attribute__((section("vmem"))) \
- 	__attribute__((aligned(8))) \
+ 	__attribute__((aligned(__alignof__(vmem_t)))) \
  	__attribute__((used)) \
 	const vmem_t vmem_##name_in = { \
 		.type = VMEM_TYPE_FILE, \
@@ -54,18 +64,18 @@ void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, ui
 	};
 
 #define VMEM_DEFINE_FILE_VADDR(name_in, strname, filename_in, size_in, fixed_vaddr) \
-	static vmem_file_driver_t vmem_##name_in##_driver = { \
+	static vmem_file_vaddr_driver_t vmem_##name_in##_driver = { \
 		.filename = filename_in, \
 	}; \
 	__attribute__((section("vmem"))) \
- 	__attribute__((aligned(8))) \
+ 	__attribute__((aligned(__alignof__(vmem_t)))) \
  	__attribute__((used)) \
 	const vmem_t vmem_##name_in = { \
 		.type = VMEM_TYPE_FILE, \
 		.name = strname, \
 		.size = size_in, \
-		.read = vmem_file_read, \
-		.write = vmem_file_write, \
+		.read = vmem_file_vaddr_read, \
+		.write = vmem_file_vaddr_write, \
 		.driver = &vmem_##name_in##_driver, \
 		.vaddr = (uint64_t)fixed_vaddr, \
 		.ack_with_pull = 1, \

--- a/include/vmem/vmem_file.h
+++ b/include/vmem/vmem_file.h
@@ -19,10 +19,10 @@
 
 #if __64BIT__
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr = (uint64_t)&vmem_##name_in##_buf
+		.vaddr = (uint64_t)vmem_##name_in##_buf
 #else
 #define VMEM_FILE_VADDR_INITIALIZER(name_in) \
-		.vaddr32 = (uint32_t)&vmem_##name_in##_buf, \
+		.vaddr32 = (uint32_t)vmem_##name_in##_buf, \
 		.vaddr_pad = 0
 #endif
 
@@ -50,7 +50,7 @@ void vmem_file_vaddr_write(const vmem_t * vmem, uint64_t addr, const void * data
 		.filename = filename_in, \
 	}; \
 	__attribute__((section("vmem"))) \
- 	__attribute__((aligned(__alignof__(vmem_t)))) \
+ 	__attribute__((aligned(8))) \
  	__attribute__((used)) \
 	const vmem_t vmem_##name_in = { \
 		.type = VMEM_TYPE_FILE, \

--- a/include/vmem/vmem_file.h
+++ b/include/vmem/vmem_file.h
@@ -77,8 +77,9 @@ void vmem_file_vaddr_write(const vmem_t * vmem, uint64_t addr, const void * data
 		.read = vmem_file_vaddr_read, \
 		.write = vmem_file_vaddr_write, \
 		.driver = &vmem_##name_in##_driver, \
-		.vaddr = (uint64_t)fixed_vaddr, \
-		.ack_with_pull = 1, \
+		/* We ensure bit 59 is set so that no malloc'ed value will collide with these vaddr */ \
+		.vaddr = (1<<59) | (uint64_t)fixed_vaddr, \
+    .ack_with_pull = 1, \
 	};
 
 #endif /* LIB_PARAM_INCLUDE_VMEM_VMEM_FILE_H_ */

--- a/src/vmem/vmem_file.c
+++ b/src/vmem/vmem_file.c
@@ -21,7 +21,10 @@ void vmem_file_init(const vmem_t * vmem) {
 		if (fd != -1) {
 			driver->stream = fdopen(fd, "r+");
 		}
-		if(!driver->stream) {
+		if(driver->stream) {
+			int read = fread(driver->physaddr, 1, vmem->size, driver->stream);
+			(void) read;
+		} else {
 			printf("\nWARNING: vmem[%s]: permission/path issues for associated filename: \"%s\"\n", vmem->name, driver->filename);
 		}
 	}
@@ -30,6 +33,40 @@ void vmem_file_init(const vmem_t * vmem) {
 void vmem_file_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t len) {
 	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
 	vmem_file_init(vmem);
+	memcpy(dataout, (void*)((intptr_t)driver->physaddr + addr), len);
+}
+
+void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len) {
+	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
+	memcpy((void *)((intptr_t)driver->physaddr + addr), datain, len);
+	vmem_file_init(vmem);
+	if(driver->stream ) {
+		/* Flush back to file */
+		int res = fseek(driver->stream, addr, SEEK_SET);
+		(void)res;
+		int written = fwrite((void*)((intptr_t)driver->physaddr + addr), len, 1, driver->stream);
+		fflush(driver->stream);
+		(void) written;
+	}
+}
+
+static void vmem_file_vaddr_init(const vmem_t * vmem) {
+	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
+	if(driver->stream == NULL) {
+		/* Open file for reading/writing, creating it if it doesn't exist */
+		int fd = open(driver->filename, O_RDWR|O_CREAT, S_IRUSR|S_IWUSR);
+		if (fd != -1) {
+			driver->stream = fdopen(fd, "r+");
+		}
+		if(!driver->stream) {
+			printf("\nWARNING: vmem[%s]: permission/path issues for associated filename: \"%s\"\n", vmem->name, driver->filename);
+		}
+	}
+}
+
+void vmem_file_vaddr_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t len) {
+	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
+	vmem_file_vaddr_init(vmem);
 	if(driver->stream ) {
 	    int res = fseek(driver->stream, addr, SEEK_SET);
 		(void)res;
@@ -38,9 +75,9 @@ void vmem_file_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t
 	}
 }
 
-void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len) {
+void vmem_file_vaddr_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len) {
 	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
-	vmem_file_init(vmem);
+	vmem_file_vaddr_init(vmem);
 	if(driver->stream ) {
 		/* Flush back to file */
 		int res = fseek(driver->stream, addr, SEEK_SET);

--- a/src/vmem/vmem_file.c
+++ b/src/vmem/vmem_file.c
@@ -21,10 +21,7 @@ void vmem_file_init(const vmem_t * vmem) {
 		if (fd != -1) {
 			driver->stream = fdopen(fd, "r+");
 		}
-		if(driver->stream) {
-			int read = fread(driver->physaddr, 1, vmem->size, driver->stream);
-			(void) read;
-		} else {
+		if(!driver->stream) {
 			printf("\nWARNING: vmem[%s]: permission/path issues for associated filename: \"%s\"\n", vmem->name, driver->filename);
 		}
 	}
@@ -33,18 +30,22 @@ void vmem_file_init(const vmem_t * vmem) {
 void vmem_file_read(const vmem_t * vmem, uint64_t addr, void * dataout, uint32_t len) {
 	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
 	vmem_file_init(vmem);
-	memcpy(dataout, (void*)((intptr_t)driver->physaddr + addr), len);
+	if(driver->stream ) {
+	    int res = fseek(driver->stream, addr, SEEK_SET);
+		(void)res;
+	    res = fread(dataout, len, 1, driver->stream);
+		(void)res;
+	}
 }
 
 void vmem_file_write(const vmem_t * vmem, uint64_t addr, const void * datain, uint32_t len) {
 	vmem_file_driver_t *driver = (vmem_file_driver_t *) vmem->driver;
-	memcpy((void *)((intptr_t)driver->physaddr + addr), datain, len);
 	vmem_file_init(vmem);
 	if(driver->stream ) {
 		/* Flush back to file */
 		int res = fseek(driver->stream, addr, SEEK_SET);
 		(void)res;
-		int written = fwrite((char *) driver->physaddr + addr, len, 1, driver->stream);
+		int written = fwrite(datain, len, 1, driver->stream);
 		fflush(driver->stream);
 		(void) written;
 	}


### PR DESCRIPTION
This reduces artificial RAM requirement for processes using VMEM file objects, at the (relative) expense of speed, but if speed is needed, then VMEM block objects (which offer configurable caching) can be used