### PR TITLE
Send ACK even if not all parameters in push request are recognised

### DIFF
--- a/src/param/param_server.c
+++ b/src/param/param_server.c
@@ -185,12 +185,9 @@ static void param_serve_push(csp_packet_t * packet, int send_ack, int version) {
 
 	param_queue_t queue;
 	param_queue_init(&queue, &packet->data[2], packet->length - 2, packet->length - 2, PARAM_QUEUE_TYPE_SET, version);
-	int result = param_queue_apply(&queue, packet->id.src, 0);
+	param_queue_apply(&queue, packet->id.src, 0);
 
-	if ((result != 0) || (send_ack == 0)) {
-		if (result != 0) {
-			printf("Param serve push error, result = %d\n", result);
-		}
+	if (send_ack == 0) {
 		csp_buffer_free(packet);
 		return;
 	}


### PR DESCRIPTION
When typing `switch X` in CSH, the client throws a `push queue error` after the configured timeout and the module is leaving a `Param serve push error, result = -1` in stdbuf due to the client also setting parameters boot_img2/3 in case they exist.

Since ack_with_pull was introduced, the user will see the parameters actually set in the ACK, so I see not reason why the server simply shall hold back the ACK in case not all values can be handled.