### PR TITLE
feat(limits): initial suggestion for limits

### DIFF
--- a/include/param/param.h
+++ b/include/param/param.h
@@ -120,7 +120,7 @@ typedef union param_bound_u {
 #define PM_PRIO3               (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 #define PM_PRIO_MASK           (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 
-#define PM_RANGE               (1 << 14) //! unused
+#define PM_UNUSED               (1 << 14) //! unused
 #define PM_HIDDEN              (1 << 15) //! H: Hidden parameter 
 
 /* Reserved flags:

--- a/include/param/param.h
+++ b/include/param/param.h
@@ -158,6 +158,7 @@ typedef struct param_s {
 	void * addr; /* Physical address */
 	const struct vmem_s * vmem;
 	void (*callback)(const struct param_s * param, int offset);
+	void (*pre_set)(const struct param_s * param, int offset, void * value);
 
 	#ifdef PARAM_HAVE_TIMESTAMP
 	csp_timestamp_t * timestamp;
@@ -263,6 +264,8 @@ static const uint16_t node_self = 0;
 		.addr = (void *)(_physaddr), \
 		.vaddr = 0, \
 		.docstr = _docstr, \
+		.min = { .PARAM_BMEMBER(_type) = (_min) }, \
+		.max = { .PARAM_BMEMBER(_type) = (_max) }, \
 	}
 
 #define PARAM_DEFINE_STATIC_VMEM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _vmem_name, _vmem_addr, _docstr) \

--- a/include/param/param.h
+++ b/include/param/param.h
@@ -148,7 +148,7 @@ typedef struct param_s {
 	
 	uint64_t vaddr; /* Virtual address in case of VMEM */
 
-	param_bound_t min;   /* active only when PM_RANGE set */
+	param_bound_t min;
 	param_bound_t max;
 
 	uint16_t * node;
@@ -256,7 +256,7 @@ static const uint16_t node_self = 0;
 		.name = #_name, \
 		.array_size = _array_count < 1 ? 1 : _array_count, \
 		.array_step = _array_step, \
-		.mask = (_flags) | PM_RANGE, \
+		.mask = _flags, \
 		.unit = _unit, \
 		.callback = _callback, \
 		PARAM_TIMESTAMP_INIT(_name) \

--- a/include/param/param.h
+++ b/include/param/param.h
@@ -58,6 +58,32 @@ typedef enum {
 #define PARAM_CTYPE_PARAM_TYPE_STRING  char
 #define PARAM_CTYPE_PARAM_TYPE_DATA  char
 
+/* Boundary union for parameter values. This is used to store the min/max values of a parameter in a type-agnostic way. */
+typedef union param_bound_u {
+    int64_t  i;
+    uint64_t u;
+    float    f;
+    double   d;
+} param_bound_t;
+
+#define PARAM_BMEMBER_PARAM_TYPE_UINT8   u
+#define PARAM_BMEMBER_PARAM_TYPE_UINT16  u
+#define PARAM_BMEMBER_PARAM_TYPE_UINT32  u
+#define PARAM_BMEMBER_PARAM_TYPE_UINT64  u
+#define PARAM_BMEMBER_PARAM_TYPE_INT8    i
+#define PARAM_BMEMBER_PARAM_TYPE_INT16   i
+#define PARAM_BMEMBER_PARAM_TYPE_INT32   i
+#define PARAM_BMEMBER_PARAM_TYPE_INT64   i
+#define PARAM_BMEMBER_PARAM_TYPE_XINT8   u
+#define PARAM_BMEMBER_PARAM_TYPE_XINT16  u
+#define PARAM_BMEMBER_PARAM_TYPE_XINT32  u
+#define PARAM_BMEMBER_PARAM_TYPE_XINT64  u
+#define PARAM_BMEMBER_PARAM_TYPE_FLOAT   f
+#define PARAM_BMEMBER_PARAM_TYPE_DOUBLE  d
+#define PARAM_BMEMBER_PARAM_TYPE_STRING  i  /* unused */
+#define PARAM_BMEMBER_PARAM_TYPE_DATA    i  /* unused */
+#define PARAM_BMEMBER(_ptype_token) PARAM_BMEMBER_##_ptype_token
+
 
 /* “Selector” macro */
 #define PARAM_CTYPE(_ptype_token) PARAM_CTYPE_##_ptype_token
@@ -94,6 +120,7 @@ typedef enum {
 #define PM_PRIO3               (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 #define PM_PRIO_MASK           (3 << 12) //! q: Priority of parameter for logging and retrieval (two bits)
 
+#define PM_RANGE               (1 << 14) //! unused
 #define PM_HIDDEN              (1 << 15) //! H: Hidden parameter 
 
 /* Reserved flags:
@@ -120,6 +147,9 @@ typedef enum {
 typedef struct param_s {
 	
 	uint64_t vaddr; /* Virtual address in case of VMEM */
+
+	param_bound_t min;   /* active only when PM_RANGE set */
+	param_bound_t max;
 
 	uint16_t * node;
 	char *name;
@@ -211,7 +241,7 @@ static const uint16_t node_self = 0;
 
 
 
-#define PARAM_DEFINE_STATIC_RAM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _physaddr, _docstr) \
+#define PARAM_DEFINE_STATIC_RAM(_id, _name, _type, _array_count, _array_step, _flags, _callback, _unit, _physaddr, _docstr, _min, _max) \
 	_Static_assert(((_array_count) <= 1) ? 1 : ((_array_step) >= PARAM_SIZEOF(_type)), "param: array_step invalid for array_count"); \
 	_Static_assert(((_array_count) <= 1) ? 1 : (((_array_step) % PARAM_ALIGNOF(_type)) == 0U),"param: array_step not aligned to type"); \
 	PARAM_TYPECHECK(_name, _type, _physaddr); \
@@ -226,7 +256,7 @@ static const uint16_t node_self = 0;
 		.name = #_name, \
 		.array_size = _array_count < 1 ? 1 : _array_count, \
 		.array_step = _array_step, \
-		.mask = _flags, \
+		.mask = (_flags) | PM_RANGE, \
 		.unit = _unit, \
 		.callback = _callback, \
 		PARAM_TIMESTAMP_INIT(_name) \

--- a/src/param/param.c
+++ b/src/param/param.c
@@ -98,8 +98,9 @@ void param_get_data(const param_t * param, void * outbuf, int len)
 			return; \
 		} \
 		{ \
-			__typeof__(param->min._bmem) _v = (__typeof__(param->min._bmem)) value; \
-			if ((_v < param->min._bmem) || (_v > param->max._bmem)) { \
+			_type _min = (_type) param->min._bmem; \
+			_type _max = (_type) param->max._bmem; \
+			if ((value < _min) || (value > _max)) { \
 				return; /* out of range: leave stored value unchanged */ \
 			} \
 		} \

--- a/src/param/param.c
+++ b/src/param/param.c
@@ -91,7 +91,7 @@ void param_get_data(const param_t * param, void * outbuf, int len)
 #define param_log(...)
 #endif
 
-#define PARAM_SET(_type, name_in, _swapfct) \
+#define PARAM_SET(_type, name_in, _swapfct, _bmem) \
 	void __param_set_##name_in(const param_t * param, _type value, bool do_callback, unsigned int i); \
 	void __param_set_##name_in(const param_t * param, _type value, bool do_callback, unsigned int i) { \
 		if (i >= (unsigned int) param->array_size) { \

--- a/src/param/param.c
+++ b/src/param/param.c
@@ -97,6 +97,12 @@ void param_get_data(const param_t * param, void * outbuf, int len)
 		if (i >= (unsigned int) param->array_size) { \
 			return; \
 		} \
+		{ \
+			__typeof__(param->min._bmem) _v = (__typeof__(param->min._bmem)) value; \
+			if ((_v < param->min._bmem) || (_v > param->max._bmem)) { \
+				return; /* out of range: leave stored value unchanged */ \
+			} \
+		} \
 		if (param->vmem) { \
 			if (param->vmem->big_endian == 1) \
 				value = _swapfct(value); \
@@ -130,16 +136,16 @@ void param_get_data(const param_t * param, void * outbuf, int len)
 		__param_set_##name_in(param, value, false, i); \
 	}
 
-PARAM_SET(uint8_t, uint8, )
-PARAM_SET(uint16_t, uint16, htobe16)
-PARAM_SET(uint32_t, uint32, htobe32)
-PARAM_SET(uint64_t, uint64, htobe64)
-PARAM_SET(int8_t, int8, )
-PARAM_SET(int16_t, int16, htobe16)
-PARAM_SET(int32_t, int32, htobe32)
-PARAM_SET(int64_t, int64, htobe64)
-PARAM_SET(float, float, )
-PARAM_SET(double, double, )
+PARAM_SET(uint8_t,  uint8,  ,        u)
+PARAM_SET(uint16_t, uint16, htobe16, u)
+PARAM_SET(uint32_t, uint32, htobe32, u)
+PARAM_SET(uint64_t, uint64, htobe64, u)
+PARAM_SET(int8_t,   int8,   ,        i)
+PARAM_SET(int16_t,  int16,  htobe16, i)
+PARAM_SET(int32_t,  int32,  htobe32, i)
+PARAM_SET(int64_t,  int64,  htobe64, i)
+PARAM_SET(float,    float,  ,        f)
+PARAM_SET(double,   double, ,        d)
 
 #undef PARAM_SET
 


### PR DESCRIPTION
Initial suggestion for how we could add limits.

Do we want to break PARAM_DEFINE API or try and keep backwards compat?
We could use PM_LIMITS flag to conditionally check

The param_t struct grows by 16 bytes 2*8

We could also just make a pre set callback for the user something like:

if (param->pre_set) { \
            if (param->pre_set(param, i, &value) == false) { \
                return; \
            } \
        } \
        
We could have both or one of these.

We might also extend union to have 32bits

