### PR TITLE
Parameter user masks must be represented as hex

### DIFF
--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -749,7 +749,7 @@ void list_add_output_user_flags(uint32_t mask, FILE * out) {
 		for (uint8_t i = PM_USER_FLAGS_OFFSET; i < 8*sizeof(mask); i++) {
 			if (mask & (1<<i)) {
 				mask &= ~ (1<<i);
-				fprintf(out, "%"PRIu8, i-PM_USER_FLAGS_OFFSET);
+				fprintf(out, "%"PRIx8, i-PM_USER_FLAGS_OFFSET);
 			}
 		}
 


### PR DESCRIPTION
CSH expects one mask per letter (0-f) when parsing the list add command
partool already comply to this