### PR TITLE
Fix/PLT 406 param list clear function clears local parameter

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -80,11 +80,7 @@ if get_option('collector') == true
 endif
 
 param_inc = include_directories('.', 'include')
-if get_option('default_library') == 'static'
-	deps = [clib_dep, bsd_dep, csp_dep.partial_dependency(includes:true)]
-else
-	deps = [clib_dep, bsd_dep, csp_dep]
-endif
+deps = [clib_dep, bsd_dep, csp_dep]
 param_lib = library('param',
 	sources: [param_src, libparam_h],
 	include_directories : param_inc,

--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -413,10 +413,12 @@ static void param_list_destroy_impl(const param_t * param) {
 #ifdef PARAM_LIST_DYNAMIC
 
 void param_list_clear(void) {
-	while (!SLIST_EMPTY(&param_list_head)) {
-		struct param_s *param = SLIST_FIRST(&param_list_head);
-		SLIST_REMOVE_HEAD(&param_list_head, next);
-		param_list_destroy(param);
+	struct param_s *iter = 0;
+	SLIST_FOREACH(iter, &param_list_head, next) {
+		if(*iter->node != 0) {
+			SLIST_REMOVE(&param_list_head, iter, param_s, next);
+			param_list_destroy(iter);
+		}
 	}
 }
 

--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -417,7 +417,8 @@ void param_list_clear(void) {
 	SLIST_FOREACH(iter, &param_list_head, next) {
 		if(*iter->node != 0) {
 			SLIST_REMOVE(&param_list_head, iter, param_s, next);
-			param_list_destroy(iter);
+			struct param_s to_be_destroyed = *iter;
+			param_list_destroy(&to_be_destroyed);
 		}
 	}
 }

--- a/src/param/list/param_list.c
+++ b/src/param/list/param_list.c
@@ -413,13 +413,16 @@ static void param_list_destroy_impl(const param_t * param) {
 #ifdef PARAM_LIST_DYNAMIC
 
 void param_list_clear(void) {
-	struct param_s *iter = 0;
-	SLIST_FOREACH(iter, &param_list_head, next) {
-		if(*iter->node != 0) {
-			SLIST_REMOVE(&param_list_head, iter, param_s, next);
-			struct param_s to_be_destroyed = *iter;
-			param_list_destroy(&to_be_destroyed);
+	param_list_iterator i = {0};
+	const param_t * iter_param = param_list_iterate(&i);
+
+	while (iter_param) {
+		const param_t * param = iter_param;
+		if (i.phase != 0 && (i.element && *(i.element->node) != 0)) {
+			SLIST_REMOVE(&param_list_head, param, param_s, next);
+			param_list_destroy(param);
 		}
+		iter_param = param_list_iterate(&i);
 	}
 }
 

--- a/tests/linux.ld
+++ b/tests/linux.ld
@@ -1,0 +1,11 @@
+SECTIONS
+{
+	.param ALIGN(8) :
+	{
+		PROVIDE(__start_param = .);
+		KEEP(*(SORT_BY_NAME(param*)))
+		. = ALIGN(8);
+		PROVIDE(__stop_param = .);
+	}
+}
+INSERT AFTER .rodata;

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,4 +1,6 @@
+linker_script = meson.current_source_dir() / 'linux.ld'
+
 plt_405_exe = executable('plt_405', 'plt_405.c', dependencies: [param_dep, csp_dep])
 test('plt_405', plt_405_exe)
-plt_406_exe = executable('plt_406', 'plt_406.c', dependencies: [param_dep, csp_dep], link_args : ['-Wl,-Map=plt_406.map'])
+plt_406_exe = executable('plt_406', 'plt_406.c', dependencies: [param_dep, csp_dep], link_args : ['-Wl,--script=' + linker_script])
 test('plt_406', plt_406_exe)

--- a/tests/meson.build
+++ b/tests/meson.build
@@ -1,2 +1,4 @@
 plt_405_exe = executable('plt_405', 'plt_405.c', dependencies: [param_dep, csp_dep])
 test('plt_405', plt_405_exe)
+plt_406_exe = executable('plt_406', 'plt_406.c', dependencies: [param_dep, csp_dep], link_args : ['-Wl,-Map=plt_406.map'])
+test('plt_406', plt_406_exe)

--- a/tests/plt_405.c
+++ b/tests/plt_405.c
@@ -13,5 +13,5 @@ int main (int argc, char *argv[]) {
     vmem_write(vmem_plt_405.vaddr, test_vector, sizeof(test_vector));
     vmem_read(buf, vmem_plt_405.vaddr, sizeof(test_vector));
     assert(0 == memcmp(buf, test_vector, sizeof(test_vector)));
-    return 1;
+    return 0;
 }

--- a/tests/plt_406.c
+++ b/tests/plt_406.c
@@ -21,12 +21,14 @@ int main (int argc, char *argv[]) {
 
     /* Add a remote parameter with node = 0 */
     param_t *remote = param_list_create_remote(128, 0, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
+    assert(p);
     param_list_add(remote);
     p = param_list_find_id(0, 128);
     assert(p);
 
     /* Add a remote parameter with node != 0 */
     remote = param_list_create_remote(128, 400, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
+    assert(remote);
     param_list_add(remote);
     p = param_list_find_id(400, 128);
     assert(p);
@@ -34,7 +36,7 @@ int main (int argc, char *argv[]) {
     /* Clear the list */
     param_list_clear();
 
-    /* Can you we still find our own added remote parameter with node = 0 ? */
+    /* Can we still find our own added remote parameter with node = 0 ? */
     p = param_list_find_id(0, 128);
     assert(p);
 
@@ -44,6 +46,7 @@ int main (int argc, char *argv[]) {
 
     /* Explicitly remove our own remote parameter with node = 0 ? */
     p = param_list_find_id(0, 128);
+    assert(p);
     param_list_remove_specific(p, 0, 1);
     p = param_list_find_id(0, 128);
     assert(NULL == p);

--- a/tests/plt_406.c
+++ b/tests/plt_406.c
@@ -1,0 +1,55 @@
+#include <assert.h>
+#include <string.h>
+#include <param/param.h>
+#include <param/param_list.h>
+
+static int32_t _plt_406;
+
+PARAM_DEFINE_STATIC_RAM(1, plt_406, PARAM_TYPE_INT32, 0, 1, PM_READONLY, NULL, "-", &_plt_406, "PLT 406 test parameter");
+
+int main (int argc, char *argv[]) {
+    (void)argc;
+    (void)argv;
+    /* Make sure our own param (id = 1) is in the list */
+    const param_t * p = param_list_find_id(0, 1);
+    if(NULL == p) {
+        /* libparam is probably built as a shared library -> need to explicitly add our own parameters*/
+        param_list_add((param_t *)&plt_406);
+    }
+    p = param_list_find_id(0, 1);
+    assert(p);
+
+    /* Add a remote parameter with node = 0 */
+    param_t *remote = param_list_create_remote(128, 0, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
+    param_list_add(remote);
+    p = param_list_find_id(0, 128);
+    assert(p);
+
+    /* Add a remote parameter with node != 0 */
+    remote = param_list_create_remote(128, 400, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
+    param_list_add(remote);
+    p = param_list_find_id(400, 128);
+    assert(p);
+
+    /* Clear the list */
+    param_list_clear();
+
+    /* Can you we still find our own added remote parameter with node = 0 ? */
+    p = param_list_find_id(0, 128);
+    assert(p);
+
+    /* Did we remove the remote parameter (node != 0) from the list ? */
+    p = param_list_find_id(400, 128);
+    assert(NULL == p);
+
+    /* Explicitly remove our own remote parameter with node = 0 ? */
+    p = param_list_find_id(0, 128);
+    param_list_remove_specific(p, 0, 1);
+    p = param_list_find_id(0, 128);
+    assert(NULL == p);
+
+    /* Can we still find our local parameter ? */
+    p = param_list_find_id(0, 1);
+    assert(p);
+    return 0;
+}

--- a/tests/plt_406.c
+++ b/tests/plt_406.c
@@ -14,20 +14,22 @@ int main (int argc, char *argv[]) {
     const param_t * p = param_list_find_id(0, 1);
     if(NULL == p) {
         /* libparam is probably built as a shared library -> need to explicitly add our own parameters*/
-        param_list_add((param_t *)&plt_406);
+        param_t *local = param_list_create_remote(1, 0, PARAM_TYPE_INT32, PM_READONLY, 1, "plt_406", "-", "PLT 406 test parameter", -1);
+        assert(local);
+        param_list_add(local);
     }
     p = param_list_find_id(0, 1);
     assert(p);
 
-    /* Add a remote parameter with node = 0 */
+    /* Add a "fake" remote parameter with node = 0 */
     param_t *remote = param_list_create_remote(128, 0, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
-    assert(p);
+    assert(remote);
     param_list_add(remote);
     p = param_list_find_id(0, 128);
     assert(p);
 
     /* Add a remote parameter with node != 0 */
-    remote = param_list_create_remote(128, 400, PARAM_TYPE_UINT16, PM_DEBUG, 0, "remote", NULL, NULL, -1);
+    remote = param_list_create_remote(128, 400, PARAM_TYPE_UINT16, PM_REMOTE, 0, "remote", NULL, NULL, -1);
     assert(remote);
     param_list_add(remote);
     p = param_list_find_id(400, 128);


### PR DESCRIPTION
Local parameters (whose node == 0) are usually placed in a specific “param” ELF section and are read-only.

In module code, remote parameters are added to a linked list, independent of the of the read-only “param” ELF section.

However, in CSH context, APMs that define their own parameters, add those parameters to the linked-list during initialization (by calling param_list_add()). Those parameters are in essence local not remote (they are part of the CSH instance local parameters).

When some code calls the param_list_clear() function (for instance from hk_store.c, part of OBC House Keeping), the linked list is essentially reset, causing the list of CSH parameters to revert back to the list as it was before loading any APM.